### PR TITLE
fix two factor anova

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -70,7 +70,7 @@ ptukey_speed <- function(qstats, sizes) {
     .Call('_pmartR_ptukey_speed', PACKAGE = 'pmartR', qstats, sizes)
 }
 
-two_factor_anova_cpp <- function(y, X_full, X_red, red_df) {
-    .Call('_pmartR_two_factor_anova_cpp', PACKAGE = 'pmartR', y, X_full, X_red, red_df)
+two_factor_anova_cpp <- function(y, X_full, X_red, red_df, group_ids) {
+    .Call('_pmartR_two_factor_anova_cpp', PACKAGE = 'pmartR', y, X_full, X_red, red_df, group_ids)
 }
 

--- a/R/anova_helper_fun.R
+++ b/R/anova_helper_fun.R
@@ -2,22 +2,21 @@
 run_twofactor_cpp <- function(data,gpData,red_df){
   #Create design matrix for reduced model, i.e., no interaction effect
   colnames(gpData)[-c(1,2)] <- c("Factor1","Factor2")
-  gpData <- cbind(gpData,y=1:nrow(gpData))#,Factor3=paste0(gpData$Factor1,gpData$Factor2))
+  gpData <- cbind(gpData,y=1:nrow(gpData))
   
   #Create design matrix for the full model, i.e., all first order and interaction effects
   Xred <- unname(model.matrix(lm(y~Factor1+Factor2-1,data=gpData)))
   Xfull <- unname(model.matrix(lm(y~Factor1*Factor2-1,data=gpData)))
   
   #Run the two factor ANOVA model 
-  #Edit 2/16: add "group_ids" so C++ knows which groups belong to which columns
+  #Edit 2/16: add "group_ids" so C++ knows which groups belong to which columns, helps with handling NaNs
   res <- two_factor_anova_cpp(data,Xfull,Xred,red_df, group_ids=as.numeric(as.factor(gpData$Group)))
   
   #Get the unique group levels to translate ANOVA parameters into group means
   red_gpData <- dplyr::distinct(gpData,Group,.keep_all=TRUE)
   red_gpData <- dplyr::arrange(red_gpData,y)
   
-  #pars_to_means <- unname(model.matrix(lm(y~Factor1*Factor2,data=red_gpData)))
-  means <- res$par_estimates#%*%t(pars_to_means)
+  means <- res$par_estimates
   colnames(means) <- red_gpData$Group
   
   res$group_means <- means

--- a/R/anova_helper_fun.R
+++ b/R/anova_helper_fun.R
@@ -2,21 +2,22 @@
 run_twofactor_cpp <- function(data,gpData,red_df){
   #Create design matrix for reduced model, i.e., no interaction effect
   colnames(gpData)[-c(1,2)] <- c("Factor1","Factor2")
-  gpData <- cbind(gpData,y=1:nrow(gpData))
+  gpData <- cbind(gpData,y=1:nrow(gpData))#,Factor3=paste0(gpData$Factor1,gpData$Factor2))
   
   #Create design matrix for the full model, i.e., all first order and interaction effects
-  Xred <- unname(model.matrix(lm(y~Factor1+Factor2,data=gpData)))
-  Xfull <- unname(model.matrix(lm(y~Factor1*Factor2,data=gpData)))
+  Xred <- unname(model.matrix(lm(y~Factor1+Factor2-1,data=gpData)))
+  Xfull <- unname(model.matrix(lm(y~Factor1*Factor2-1,data=gpData)))
   
-  #Run the two factor ANOVA model
-  res <- two_factor_anova_cpp(data,Xfull,Xred,red_df)
+  #Run the two factor ANOVA model 
+  #Edit 2/16: add "group_ids" so C++ knows which groups belong to which columns
+  res <- two_factor_anova_cpp(data,Xfull,Xred,red_df, group_ids=as.numeric(as.factor(gpData$Group)))
   
   #Get the unique group levels to translate ANOVA parameters into group means
   red_gpData <- dplyr::distinct(gpData,Group,.keep_all=TRUE)
   red_gpData <- dplyr::arrange(red_gpData,y)
   
-  pars_to_means <- unname(model.matrix(lm(y~Factor1*Factor2,data=red_gpData)))
-  means <- res$par_estimates%*%t(pars_to_means)
+  #pars_to_means <- unname(model.matrix(lm(y~Factor1*Factor2,data=red_gpData)))
+  means <- res$par_estimates#%*%t(pars_to_means)
   colnames(means) <- red_gpData$Group
   
   res$group_means <- means

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -169,7 +169,7 @@ anova_test <- function(omicsData, comparisons = NULL, pval_adjust = 'none', pval
     #The new "data" are the paired differences, so overwrite data with paried differences
     #Rcpp::sourceCpp('src/fc_functions.cpp')
     #data <- fold_change_diff_na_okay(data = data.matrix(omicsData$e_data[,-1]),C = t(pid_matrix)) #This failed if columns didn't 
-    data <- fold_change_diff_na_okay(data = data.matrix(omicsData$e_data[,omicsData$f_data[,samp_cname]]),C = t(pid_matrix))
+    data <- fold_change_diff_na_okay(data = data.matrix(omicsData$e_data[,as.character(omicsData$f_data[,samp_cname])]),C = t(pid_matrix))
     
     #Add columns names 
     if(is.numeric(omicsData$f_data[,pair_col])){

--- a/R/anova_test.R
+++ b/R/anova_test.R
@@ -212,8 +212,10 @@ anova_test <- function(omicsData, comparisons = NULL, pval_adjust = 'none', pval
     cov_samp_col <- which(colnames(covariates)==samp_cname)
     if(length(cov_samp_col)==0){
       warning(paste(samp_cname,"information is missing from provided covariates thus covariates will be ignored"))
+      red_df <- matrix(rep(0,nrow(data)),ncol=1)
     }else if(any(is.na(covariates[,-cov_samp_col]))){
       warning("Missing values were detected in the provided covariates thus covariates will be ignored")
+      red_df <- matrix(rep(0,nrow(data)),ncol=1)
     }else{
       #Add group ids to covariate ids
       covariates <- merge(groupData, covariates,sort=FALSE)

--- a/R/covariate_supp_funs.R
+++ b/R/covariate_supp_funs.R
@@ -38,13 +38,19 @@ reduce_xmatrix <- function(x,ngroups){
   p <- ncol(x)
   orig_rank <- qr(x)$rank
   if(orig_rank<p){
-    stdx <- apply(x,2,function(mat) (mat-mean(mat))/sd(mat))
-    dmat <- as.matrix(dist(t(stdx)))
-    dmat <- dmat[(1:ngroups),-(1:ngroups)]
-    if(any(dmat==0)){
-      ind_mat <- matrix(1:ngroups,ngroups,(p-ngroups))
-      cols_to_remove <- ind_mat[which(dmat==0)]
-      x[,cols_to_remove] <- 0
+    #Remove constant columns
+    col_sds <- apply(x,2,sd)
+    if(any(col_sds==0)){
+      x <- x[,-which(col_sds==0)]
+    }else{
+      stdx <- apply(x,2,function(mat) (mat-mean(mat))/sd(mat))
+      dmat <- as.matrix(dist(t(stdx)))
+      dmat <- dmat[(1:ngroups),-(1:ngroups)]
+      if(any(dmat==0)){
+        ind_mat <- matrix(1:ngroups,ngroups,(p-ngroups))
+        cols_to_remove <- ind_mat[which(dmat==0)]
+        x[,cols_to_remove] <- 0
+      }
     }
   }
   return(x)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -213,8 +213,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // two_factor_anova_cpp
-List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, NumericVector red_df);
-RcppExport SEXP _pmartR_two_factor_anova_cpp(SEXP ySEXP, SEXP X_fullSEXP, SEXP X_redSEXP, SEXP red_dfSEXP) {
+List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, NumericVector red_df, arma::colvec group_ids);
+RcppExport SEXP _pmartR_two_factor_anova_cpp(SEXP ySEXP, SEXP X_fullSEXP, SEXP X_redSEXP, SEXP red_dfSEXP, SEXP group_idsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -222,7 +222,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::mat >::type X_full(X_fullSEXP);
     Rcpp::traits::input_parameter< arma::mat >::type X_red(X_redSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type red_df(red_dfSEXP);
-    rcpp_result_gen = Rcpp::wrap(two_factor_anova_cpp(y, X_full, X_red, red_df));
+    Rcpp::traits::input_parameter< arma::colvec >::type group_ids(group_idsSEXP);
+    rcpp_result_gen = Rcpp::wrap(two_factor_anova_cpp(y, X_full, X_red, red_df, group_ids));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -245,7 +246,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pmartR_pooled_cv_rcpp", (DL_FUNC) &_pmartR_pooled_cv_rcpp, 2},
     {"_pmartR_rcpp_hello_world", (DL_FUNC) &_pmartR_rcpp_hello_world, 0},
     {"_pmartR_ptukey_speed", (DL_FUNC) &_pmartR_ptukey_speed, 2},
-    {"_pmartR_two_factor_anova_cpp", (DL_FUNC) &_pmartR_two_factor_anova_cpp, 4},
+    {"_pmartR_two_factor_anova_cpp", (DL_FUNC) &_pmartR_two_factor_anova_cpp, 5},
     {NULL, NULL, 0}
 };
 

--- a/src/two_factor_anova.cpp
+++ b/src/two_factor_anova.cpp
@@ -4,7 +4,7 @@ using namespace Rcpp;
 // [[Rcpp::depends(RcppArmadillo)]]
 
 // [[Rcpp::export]]
-List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, NumericVector red_df){
+List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, NumericVector red_df, arma::colvec group_ids){
   
   int i,j;
   int n = y.n_rows;
@@ -18,11 +18,15 @@ List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, Numeri
   int num_to_remove;
   int df_red, df_full;
   double sigma2_red, sigma2_full;
-  NumericVector sig_est(n), pval(n), Fstat(n);
+  NumericVector sig_est(n), pval(n), Fstat(n),  atl_one;
   arma::mat diag_mat;
-  arma::colvec par_ests(p_full);
+  arma::colvec par_ests(p_full), par_ests_temp,group_ids_nona(y.n_cols), group_ids_nona_unq;
   arma::mat parmat(n,p_full), group_sizes(n,p_full);
-  arma::rowvec gsizes(p_full);
+  arma::rowvec gsizes(p_full), csums(p_full);
+  arma::uvec zero_cols, non_zero_cols;
+  arma::uvec missing_gp,size_j;
+  
+  
   
   //Loop over rows in y
   for(i=0; i<n; i++){
@@ -34,13 +38,31 @@ List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, Numeri
     X_red_nona = X_red;
     X_full_nona = X_full;
     num_to_remove = to_remove.size();
+    group_ids_nona = group_ids-1; //Make group_ids zero indexed
     
     //Remove NAs if applicable
     for(j=(num_to_remove-1);j>=0;j--){
       yrowi_nona.shed_col(to_remove[j]);
       X_red_nona.shed_row(to_remove[j]);
       X_full_nona.shed_row(to_remove[j]);
+      group_ids_nona.shed_row(to_remove[j]);
     }
+    
+      
+    //Remove completely empty columns
+    csums = sum(X_full_nona,0);
+    zero_cols = arma::find(csums==0);
+    non_zero_cols = arma::find(csums);
+    //if(zero_cols.n_rows>0){
+    //  for(j=(zero_cols.n_rows-1);j>=0;j--){
+    //    X_full_nona.shed_col(zero_cols[j]);
+    //  }  
+    //}
+    
+    //while(rank(X_full_nona)<X_full_nona.n_cols){
+    //  X_full_nona.shed_col((X_full_nona.n_cols-1));
+    //}
+    
     df_red = X_red_nona.n_rows-rank(X_red_nona)-red_df(i); //Subtract off df spent elsewhere, e.g., on covariates
     df_full = X_full_nona.n_rows-rank(X_full_nona)-red_df(i);
 
@@ -76,14 +98,48 @@ List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, Numeri
       XFinal.cols(p_red,p_full-1).fill(0.0); //Zero out the interaction terms if they're insignificant
       sig_est(i) = sigma2_red;
     }
-      
-    par_ests = pinv(XFinal.t()*XFinal)*XFinal.t()*yrowi_nona.t();
-    //par_ests = par_ests.rows(0,(p_red-1)); //For now don't return the interaction terms
-    parmat.row(i) = par_ests.t();
+    //Rcpp::Rcout <<"Xfinal\n"<<XFinal;  
+    par_ests_temp = XFinal*pinv(XFinal.t()*XFinal)*XFinal.t()*yrowi_nona.t();
+    //Rcpp::Rcout <<"par_ests_temp \n"<<par_ests_temp<<"\n";  
+    group_ids_nona_unq=arma::unique(group_ids_nona);
+    //Rcpp::Rcout <<"size_na_gps \n"<< group_ids_nona;  
     
+    
+    if(group_ids_nona_unq.n_elem<p_full){
+      par_ests.zeros();
+      //cntr = 0;
+      
+      for(j=0;j<p_full;j++){
+        missing_gp = find(group_ids_nona_unq==j);
+        if(missing_gp.n_elem>0){
+          //Rcpp::Rcout <<"group_ids_nona \n"<< find(group_ids_nona==j)<<"\n";  
+          par_ests(j) = mean(par_ests_temp(find(group_ids_nona==j)));
+          //cntr++;
+        }else{
+          par_ests(j) = arma::datum::nan;  
+        }
+      }
+      
+    }else{
+      for(j=0;j<p_full;j++){
+        par_ests(j) = mean(par_ests_temp(find(group_ids_nona==j)));
+      }
+    }
+    
+    //Rcpp::Rcout <<"par_ests \n"<<par_ests;  
+    
+    
+    parmat.row(i) = par_ests.t();
+    //Rcpp::Rcout <<"group_ids_nona \n"<<group_ids_nona;  
     //Sum columns of to get number of observations in each group
-    gsizes = sum(XFinal,0); 
+    for(j=0;j<p_full;j++){
+      size_j = find(group_ids_nona==j);
+      gsizes(j) = size_j.n_elem;
+      //Rcpp::Rcout <<"size_j \n"<<size_j;  
+    }
+    
     group_sizes.row(i) = gsizes; //For now don't return the interaction groups
+    
   }
   return List::create(Named("par_estimates") = parmat,
                       Named("group_sizes") = group_sizes,
@@ -95,5 +151,17 @@ List two_factor_anova_cpp(arma::mat y, arma::mat X_full, arma::mat X_red, Numeri
 
 /*
 ** R
+nrows_to_kp <- nrow(data)
+ytst <- matrix(data.matrix(unname(data[1:nrows_to_kp,])),nrow=nrows_to_kp)
+grp_nums <- as.numeric(as.factor(groupData$Group))
+Xfull_nona <- Xfull[-which(is.na(ytst)),]
+Xred_nona <- Xred[-which(is.na(ytst)),]
+
+all_dat <- cbind(groupData,Y=t(ytst))
+(ad_sum <- all_dat%>%group_by(Media,Location)%>%summarize(Size=length(which(!is.na(Y))),Mean=mean(Y,na.rm=T)))
+colSums(Xfull_nona)
+colSums(Xred_nona)
+tfan <- two_factor_anova_cpp(y = ytst,X_red = Xred,X_full = Xfull,red_df,group_ids = grp_nums)
+cbind(ad_sum,Tst=t(tfan$par_estimates),Size=t(tfan$group_sizes))
 
 */


### PR DESCRIPTION
Groups with all missing data had non-missing estimates returned when using two factor anova.  The values being returned for completely missing groups were essentially imputed values from the two factor linear model fit to the non-missing groups.   Now groups with all NaN observations have NaN returned 