### PR TITLE
Add "parent_class" attribute, update "cnames" attribute

### DIFF
--- a/R/imd_anova.R
+++ b/R/imd_anova.R
@@ -158,7 +158,11 @@ imd_anova <- function(omicsData, comparisons = NULL, test_method, pval_adjust = 
     colnames(anova_fold_flags) <- gsub("^Flag_","",colnames(anova_fold_flags))
     imd_out$Flags <- anova_fold_flags
 
-    return(statRes_output(imd_out,omicsData,comparisons,test_method,pval_adjust,pval_thresh))
+    final_out <- statRes_output(imd_out,omicsData,comparisons,test_method,pval_adjust,pval_thresh)
+  
+    attr(final_out, "cnames") = attr(omicsData, "cnames")
+    attr(final_out, "parent_class") = attr(omicsData, "class")  
+    return(final_out)
     
   }else if(test_method=='gtest'){
     
@@ -175,8 +179,12 @@ imd_anova <- function(omicsData, comparisons = NULL, test_method, pval_adjust = 
     imd_out$P_values <- gtest_pvalues
     colnames(gtest_flags) <- gsub("^Flag_","",colnames(gtest_flags))
     imd_out$Flags <- gtest_flags
-
-    return(statRes_output(imd_out,omicsData,comparisons,test_method,pval_adjust,pval_thresh))
+    
+    final_out <- statRes_output(imd_out,omicsData,comparisons,test_method,pval_adjust,pval_thresh)
+  
+    attr(final_out, "cnames") = attr(omicsData, "cnames")
+    attr(final_out, "parent_class") = attr(omicsData, "class")  
+    return(final_out)    
   }
   
   #####-----Determine which p-values/flags to return--------######
@@ -256,6 +264,7 @@ imd_anova <- function(omicsData, comparisons = NULL, test_method, pval_adjust = 
   final_out <- statRes_output(imd_out,omicsData,comparisons,test_method,pval_adjust,pval_thresh)
   
   attr(final_out, "cnames") = attr(omicsData, "cnames")
+  attr(final_out, "parent_class") = attr(omicsData, "class")  
   return(final_out)
 }
 


### PR DESCRIPTION
Added a "parent_class" attribute to track what data type the stats results object is derived from, updated return statements that were not modified with the previous "cnames" attribute addition.