### PR TITLE
fix sample id column selection in rmdfilt applyfilt

### DIFF
--- a/R/applyFilt.R
+++ b/R/applyFilt.R
@@ -466,7 +466,7 @@ applyFilt.rmdFilt <- function (filter_object, omicsData,
   # Prepare the information needed to filter the data --------------------------
 
   # Extract the column number containing the sample IDs.
-  id_col <- which(names(omicsData$f_data) == get_fdata_cname(omicsData))
+  id_col <- which(names(filter_object) == get_fdata_cname(omicsData))
 
   # Sniff out the indices that fall below the threshold.
   inds <- which(filter_object$pvalue < pvalue_threshold)


### PR DESCRIPTION
@stratkg @lmbramer 

https://github.com/pmartR/pmartR/blob/2e23adbba3007b895c55cb827b74f2f7e575a245/R/applyFilt.R#L469

Currently the column index is retrieved based on f_data, and then used to select the sample_id column in the filter_object.
Other usages of id_col appear to be correct.