### PR TITLE
require group_DF in both objects in combine_lipidData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmartR
 Type: Package
 Title: Panomics Marketplace - Quality Control and Statistical Analysis for Panomics Data
-Version: 2.0.7
+Version: 2.0.8
 Date: 2022-07-25
 Authors@R: c(person("Lisa", "Bramer", email = "lisa.bramer@pnnl.gov", role = c("aut", "cre")), person("Kelly", "Stratton", email = "kelly.stratton@pnnl.gov", role = c("aut")))
 Description: Provides functionality for quality control processing and statistical analysis of mass spectrometry (MS) omics data, in particular proteomic (either at the peptide or the protein level), lipidomic, and metabolomic data. This includes data transformation, specification of groups that are to be compared against each other, filtering of features and/or samples, data normalization, data summarization (correlation, PCA), and statistical comparisons between defined groups.

--- a/R/combine_omicsdata.R
+++ b/R/combine_omicsdata.R
@@ -49,7 +49,7 @@
 #' 
 #' @export
 #' 
-combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filters = FALSE, ...) {
+combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filters = FALSE, drop_duplicate_emeta = TRUE, ...) {
   if (class(obj_1) != class(obj_2)) {
     stop(sprintf(
       "Objects must be of the same class, found %s and %s",
@@ -152,7 +152,13 @@ combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filter
     
     if (length(unique(new_emeta_ids)) != 
         length(unique(emeta_ids_1)) + length(unique(emeta_ids_2))) {
-      warning("There were e_meta identifiers that occurred in both datasets, they have been duplicated in the new object's e_meta.")
+      
+      if(drop_duplicate_emeta) {
+        warning("There were non-unique molecule identifiers in e_meta, dropping these duplicates, some meta-data information may be lost.") 
+        new_emeta <- new_emeta %>% dplyr::distinct(!!rlang::sym(new_edata_cname), .keep_all = TRUE)
+      } else {
+        warning("There were non-unique molecule identifiers in e_meta, this may cause the object construction to fail if edata_cname and emeta_cname do not specify unique rows in the combined e_meta")
+      }
     }
     
   } else{

--- a/R/combine_omicsdata.R
+++ b/R/combine_omicsdata.R
@@ -6,7 +6,8 @@
 #' to the new object (defaults to FALSE).
 #' @param retain_filters Whether to retain filter information in the new object 
 #' (defaults to FALSE).
-#'
+#' @param ... Extra arguments, not one of 'omicsData', 'main_effects', or 'covariates' to be passed to `pmartR::group_designation`.
+#' 
 #' @return An object of the same type as the two input objects, with their 
 #' combined data.
 #'
@@ -19,9 +20,36 @@
 #' 
 #' @md
 #'
+#' @examples
+#' library(pmartR)
+#' library(pmartRdata)
+#' 
+#' obj_1 <- pmartRdata::lipid_object_neg
+#' obj_2 <- pmartRdata::lipid_object_pos
+#' 
+#' # de-dupe any duplicate edata identifiers
+#' obj_2$e_data[,get_edata_cname(obj_2)] <- paste0("obj_2_", obj_2$e_data[,get_edata_cname(obj_2)])
+#' 
+#' combine_object <- combine_lipidData(obj_1, obj_2)
+#' 
+#' # preprocess and group the data and keep filters/grouping structure
+#' 
+#' obj_1 <- edata_transform(obj_1, "log2")
+#' obj_1 <- normalize_global(obj_1, "all", "median", apply_norm = T)
+#' obj_2 <- edata_transform(obj_2, "log2")
+#' obj_2 <- normalize_global(obj_2, "all", "median", apply_norm = T)
+#' 
+#' obj_1 <- group_designation(obj_1, "Condition")
+#' obj_2 <- group_designation(obj_2, "Condition")
+#' 
+#' obj_1 <- applyFilt(molecule_filter(obj_1), obj_1, min_num = 2)
+#' obj_2 <- applyFilt(cv_filter(obj_2),obj_2, cv_thresh = 60)
+#' 
+#' combine_lipidData(obj_1, obj_2, retain_groups = T, retain_filters = T)
+#' 
 #' @export
 #' 
-combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filters = FALSE) {
+combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filters = FALSE, ...) {
   if (class(obj_1) != class(obj_2)) {
     stop(sprintf(
       "Objects must be of the same class, found %s and %s",
@@ -88,14 +116,20 @@ combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filter
   molnames <- new_edata[,get_edata_cname(obj_1)]
   
   if(length(molnames) != length(unique(molnames))) {
-    message("Duplicate molecule identifiers were found in your combined data.")
+    warning("Duplicate molecule identifiers were found in your combined data.")
   }
   
-  # Combined f_data is simply a left join, since we require the sample names
-  # are the same.
+  # Combined fdata will keep all columns from the first dataset in the case of
+  # duplicates.
+  obj_1_fdata_colnames <- obj_1$f_data %>% 
+    dplyr::select(-dplyr::one_of(get_fdata_cname(obj_1))) %>% 
+    colnames()
+  
   new_fdata <- obj_1$f_data %>% 
-    dplyr::left_join(obj_2$f_data, 
-                     by = setNames(get_fdata_cname(obj_2), get_fdata_cname(obj_1)))
+    dplyr::left_join(
+      dplyr::select(obj_2$f_data, -dplyr::one_of(obj_1_fdata_colnames)), 
+      by = setNames(get_fdata_cname(obj_2), get_fdata_cname(obj_1))
+    )
   
   # Combine e_meta in the same way as e_data if it exists in both datasets.
   if(!is.null(obj_1$e_meta) & !is.null(obj_2$e_meta)) {
@@ -149,49 +183,121 @@ combine_lipidData <- function(obj_1, obj_2, retain_groups = FALSE, retain_filter
     attr(new_object, "filters") = filters
   }
   
-  # Set the group designation of the new object, we assume that the grouping is
-  # consistent across both objects.
+  # Set the group designation of the new objects
   if(retain_groups) {
-    if(is.null(attr(obj_1, "group_DF")) & is.null(attr(obj_2, "group_DF"))) {
-      stop("At least one object must have group information")
+    if(is.null(attr(obj_1, "group_DF")) | is.null(attr(obj_2, "group_DF"))) {
+      stop("Both objects must be grouped.")
     }
     
-    if(is.null(attr(obj_1, "group_DF"))) {
-      group_df = attr(obj_2, "group_DF")
-      tmp_fdata = obj_2$f_data
-    } else {
-      group_df = attr(obj_1, "group_DF")
-      tmp_fdata = obj_1$f_data
+    # check that main effects are functionally the same
+    n_orig_groups <- attr(obj_1, "group_DF") %>% 
+      dplyr::group_by(Group) %>% 
+      attributes() %>% 
+      `[[`("groups") %>% 
+      nrow()
+    
+    n_combined_groups <- attr(obj_1, "group_DF") %>% 
+      dplyr::left_join(
+        attr(obj_2, "group_DF"), 
+        by = setNames(get_fdata_cname(obj_2), get_fdata_cname(obj_1))
+      ) %>% 
+      dplyr::group_by(Group.x, Group.y) %>% 
+      attributes() %>% 
+      `[[`("groups") %>% 
+      nrow()
+    
+    if(n_orig_groups != n_combined_groups) {
+      stop("The main effect structures of the two omicsData objects were not identical.")
     }
     
-    samp_info = new_object$f_data[,-which(colnames(new_object$f_data) == 
-                                            get_fdata_cname(new_object))]
+    ## check covariates ##
+    # 1. Rename covariates in each fdata to a temp name
+    # 2. Join the two f_datas into a dataframe with the rename covariates
+    # 3. Group by the just the first objects covariates and then both the first and second,
+    # the number of groups should be the same in both cases if the covariate structure
+    # is the same.  If not, throw an error.
+    # 4. Run group_designation on the combined object with the first object's main effects/covariates.
+    covariates_1 <- attr(obj_1, "group_DF") %>% 
+      attributes() %>% 
+      `[[`("covariates") %>% 
+      {`[`(., -which(colnames(.) == get_fdata_cname(obj_1)))} %>% 
+      colnames()
     
-    main_matches = lapply(attr(group_df, "main_effects"), function(x) {
-      column_matches_exact(samp_info, tmp_fdata[,x])[1]
-    }) %>% unlist()
+    covariates_2 <- attr(obj_2, "group_DF") %>% 
+      attributes() %>% 
+      `[[`("covariates") %>% 
+      {`[`(., -which(colnames(.) == get_fdata_cname(obj_2)))} %>% 
+      colnames()
     
-    covariate_matches = if(!is.null(attr(group_df, "covariates"))) {
-      covnames = attr(group_df, "covariates") %>% 
-        dplyr::select(-one_of(get_fdata_cname(obj_1))) %>% 
-        colnames()
+    if(all(!sapply(list(covariates_1, covariates_2), is.null))) {
+      # renaming ...
+      tmp_covar_names_1 <- paste0("_COVARS_1_", 1:length(covariates_1))
+      tmp_covar_names_2 <- paste0("_COVARS_2_", 1:length(covariates_2))
       
-      lapply(covnames, function(x) {
-        column_matches_exact(samp_info, tmp_fdata[,x])[1]
-      }) %>% unlist()
-    } else NULL
+      rename_map_1 <- setNames(covariates_1, tmp_covar_names_1)
+      rename_map_2 <- setNames(covariates_2, tmp_covar_names_2)
+      
+      tmp_fdata1 <- obj_1$f_data %>% 
+        dplyr::rename(!!!rename_map_1)
+      tmp_fdata2 <- obj_2$f_data %>% 
+        dplyr::rename(!!!rename_map_2)
+      
+      # ... to perform a join ...
+      combined_fdatas <- tmp_fdata1 %>% 
+        dplyr::left_join(
+          tmp_fdata2,
+          by = setNames(get_fdata_cname(obj_2), get_fdata_cname(obj_1))
+       )
+      
+      # ... and check that both objects have the same covariate structure.
+      n_orig_covariate_levels_1 <- combined_fdatas %>% 
+        dplyr::group_by(
+          dplyr::across(dplyr::one_of(tmp_covar_names_1))
+        ) %>% 
+        attributes() %>% 
+        `[[`("groups") %>% 
+        nrow()
+      
+      n_orig_covariate_levels_2 <- combined_fdatas %>% 
+        dplyr::group_by(
+          dplyr::across(dplyr::one_of(tmp_covar_names_2))
+        ) %>% 
+        attributes() %>% 
+        `[[`("groups") %>% 
+        nrow()
+      
+      n_comb_covariate_levels <- combined_fdatas %>% 
+        dplyr::group_by(
+          dplyr::across(dplyr::one_of(c(tmp_covar_names_1, tmp_covar_names_2)))
+        ) %>% 
+        attributes() %>% 
+        `[[`("groups") %>% 
+        nrow()
+      
+      if (n_orig_covariate_levels_1 != n_comb_covariate_levels | 
+          n_orig_covariate_levels_2 != n_comb_covariate_levels) {
+        stop("The covariate structure of both omicsData objects was not identical.")
+      }
+    }
     
+    main_effects <-  attr(obj_1, "group_DF") %>% 
+      attributes() %>% 
+      `[[`("main_effects")
+
     message(sprintf(
       "Grouping new object with main effects: %s.%s",
-      paste(main_matches, collapse = ", "),
-      if (is.null(covariate_matches))
+      paste(main_effects, collapse = ", "),
+      if (is.null(covariates_1))
         ""
       else
-        sprintf("  Covariates: %s", paste(covariate_matches, collapse = ", "))
+        sprintf("  Covariates: %s", paste(covariates_1, collapse = ", "))
     ))
     
     new_object <- group_designation(
-      new_object, main_effects = main_matches, covariates = covariate_matches)
+      new_object, 
+      main_effects = main_effects, 
+      covariates = covariates_1,
+      ...)
   }
   
   return(new_object)

--- a/README.md
+++ b/README.md
@@ -26,13 +26,4 @@ To cite this package, please use the following:
 
 Stratton KG, Webb-Robertson BJ, McCue LA, Stanfill B, Claborne D, Godinez I, Johansen T, Thompson AM, Burnum-Johnson KE, Waters KM, Bramer LM. pmartR: quality control and statistics for mass spectrometry-based biological data. Journal of proteome research. 2019 Jan 14;18(3):1418-25.
 
-@article{stratton2019pmartr,
-  title={pmartR: quality control and statistics for mass spectrometry-based biological data},
-  author={Stratton, Kelly G and Webb-Robertson, Bobbie-Jo M and McCue, Lee Ann and Stanfill, Bryan and Claborne, Daniel and Godinez, Iobani and Johansen, Thomas and Thompson, Allison M and Burnum-Johnson, Kristin E and Waters, Katrina M and others},
-  journal={Journal of proteome research},
-  volume={18},
-  number={3},
-  pages={1418--1425},
-  year={2019},
-  publisher={ACS Publications}
-}
+[Click here for BibTex](https://scholar.googleusercontent.com/scholar.bib?q=info:6IcjsBn7MfQJ:scholar.google.com/&output=citation&scisdr=CgUDaqVkEMukmBJ56W4:AAGBfm0AAAAAYoJ_8W5KJCkfr8y5SqFSCCskqfO4aFmW&scisig=AAGBfm0AAAAAYoJ_8a-EXGaZOqyQW4KM5X6XJDLc-z-s&scisf=4&ct=citation&cd=-1&hl=en) 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pmartR
 
+[![DOI](https://zenodo.org/badge/69275428.svg)](https://zenodo.org/badge/latestdoi/69275428)
+
 This R package provides functionality for quality control processing, statistical analysis and visualization of mass spectrometry (MS) omics data, in particular proteomic (either at the peptide or the protein level; isobaric labeled or unlabled), lipidomic, and metabolomic data. This includes data transformation, specification of groups that are to be compared against each other, filtering of feature and/or samples, data normalization, data summarization (correlation, PCA), and statistical comparisons of groups of interest (ANOVA and/or independence of missing data tests). Example data to be used with this packages can be found in [pmartRdata](https://github.com/pmartR/pmartRdata).
 
 

--- a/README.md
+++ b/README.md
@@ -20,4 +20,19 @@ To get started, see the package documentation and function reference located [he
 
 Example peptide (both unlabeled and isobaric labeled), protein, metabolite and lipid data are available in the __pmartRdata__ package available on Github, [here](https://github.com/pmartR/pmartRdata)
  
+## Citation:
 
+To cite this package, please use the following:
+
+Stratton KG, Webb-Robertson BJ, McCue LA, Stanfill B, Claborne D, Godinez I, Johansen T, Thompson AM, Burnum-Johnson KE, Waters KM, Bramer LM. pmartR: quality control and statistics for mass spectrometry-based biological data. Journal of proteome research. 2019 Jan 14;18(3):1418-25.
+
+@article{stratton2019pmartr,
+  title={pmartR: quality control and statistics for mass spectrometry-based biological data},
+  author={Stratton, Kelly G and Webb-Robertson, Bobbie-Jo M and McCue, Lee Ann and Stanfill, Bryan and Claborne, Daniel and Godinez, Iobani and Johansen, Thomas and Thompson, Allison M and Burnum-Johnson, Kristin E and Waters, Katrina M and others},
+  journal={Journal of proteome research},
+  volume={18},
+  number={3},
+  pages={1418--1425},
+  year={2019},
+  publisher={ACS Publications}
+}

--- a/man/combine_lipidData.Rd
+++ b/man/combine_lipidData.Rd
@@ -4,7 +4,13 @@
 \alias{combine_lipidData}
 \title{Combines two omicsData objects with identical sample information.}
 \usage{
-combine_lipidData(obj_1, obj_2, retain_groups = FALSE, retain_filters = FALSE)
+combine_lipidData(
+  obj_1,
+  obj_2,
+  retain_groups = FALSE,
+  retain_filters = FALSE,
+  ...
+)
 }
 \arguments{
 \item{obj_1, obj_2}{Two omicsData objects of the same supported type,
@@ -15,6 +21,8 @@ to the new object (defaults to FALSE).}
 
 \item{retain_filters}{Whether to retain filter information in the new object
 (defaults to FALSE).}
+
+\item{...}{Extra arguments, not one of 'omicsData', 'main_effects', or 'covariates' to be passed to \code{pmartR::group_designation}.}
 }
 \value{
 An object of the same type as the two input objects, with their
@@ -30,4 +38,32 @@ General requirements:
 \item data attributes:  Objects must be on the same scale and both be either normalized or unnormalized.
 \item group designation:  Objects must have the same grouping structure if retain_groups = T.
 }
+}
+\examples{
+library(pmartR)
+library(pmartRdata)
+
+obj_1 <- pmartRdata::lipid_object_neg
+obj_2 <- pmartRdata::lipid_object_pos
+
+# de-dupe any duplicate edata identifiers
+obj_2$e_data[,get_edata_cname(obj_2)] <- paste0("obj_2_", obj_2$e_data[,get_edata_cname(obj_2)])
+
+combine_object <- combine_lipidData(obj_1, obj_2)
+
+# preprocess and group the data and keep filters/grouping structure
+
+obj_1 <- edata_transform(obj_1, "log2")
+obj_1 <- normalize_global(obj_1, "all", "median", apply_norm = T)
+obj_2 <- edata_transform(obj_2, "log2")
+obj_2 <- normalize_global(obj_2, "all", "median", apply_norm = T)
+
+obj_1 <- group_designation(obj_1, "Condition")
+obj_2 <- group_designation(obj_2, "Condition")
+
+obj_1 <- applyFilt(molecule_filter(obj_1), obj_1, min_num = 2)
+obj_2 <- applyFilt(cv_filter(obj_2),obj_2, cv_thresh = 60)
+
+combine_lipidData(obj_1, obj_2, retain_groups = T, retain_filters = T)
+
 }

--- a/tests/testthat/test_combine_omicsData.R
+++ b/tests/testthat/test_combine_omicsData.R
@@ -4,14 +4,30 @@ obj1 <- edata_transform(ldata, "log2")
 obj1 <- normalize_global(obj1, "all", "median", apply_norm = T)
 
 fake_cov <- c(rep("A", 5), rep("B", 6))
+fake_cov2 <- c(rep(LETTERS[1:4],2), rep(LETTERS[5], 3))
 obj1$f_data["cov"] <- fake_cov
+obj1$f_data['cov_2'] <- fake_cov2
+
+# object to be used with extra covariates
+obj3 <- obj1
+
+# object to be used with extra main effects
+obj5 <- obj1
 
 obj1 <- group_designation(obj1, "Condition", covariates = "cov")
 obj2 <- obj1
 
+obj3 <- group_designation(obj3, "Condition", covariates = c("cov", "cov_2"))
+obj4 <- obj3
+
+obj5 <- group_designation(obj5, c("Condition", "cov"), covariates = "cov_2")
+
 # Some fake edata ID's to make it unique
 obj2$e_data[,get_edata_cname(obj2)] <- paste0("obj2_", obj2$e_data[,get_edata_cname(obj2)])
 obj2$e_meta[,get_edata_cname(obj2)] <- paste0("obj2_", obj2$e_meta[,get_edata_cname(obj2)])
+
+obj4$e_data[,get_edata_cname(obj4)] <- paste0("obj4_", obj4$e_data[,get_edata_cname(obj4)])
+obj4$e_meta[,get_edata_cname(obj4)] <- paste0("obj4_", obj4$e_meta[,get_edata_cname(obj4)])
 
 obj1 <- applyFilt(molecule_filter(obj1),obj1, min_num = 2)
 obj2 <- applyFilt(cv_filter(obj2),obj2, cv_thresh = 60)
@@ -21,21 +37,49 @@ suppressWarnings({
   combn2 <- combine_lipidData(obj1, obj2, retain_groups = T)
   combn3 <- combine_lipidData(obj1, obj2, retain_groups = F, retain_filters = T)
   combn4 <- combine_lipidData(obj1, obj2, retain_groups = T, retain_filters = T)
+  combn5 <- combine_lipidData(obj1, obj3)
+  combn6 <- combine_lipidData(obj1, obj3, retain_filters = T)
+  combn7 <- combine_lipidData(obj1, obj5)
+  combn8 <- combine_lipidData(obj2, obj3, retain_filters = T)
+})
+
+test_that("bad group/covariate structures throw an error", {
+  suppressWarnings({
+    expect_error(combine_lipidData(obj3, obj2, retain_groups = T), regexp = "covariate structure")
+    expect_error(combine_lipidData(obj2, obj4, retain_groups = T), regexp = "covariate structure")
+    expect_error(combine_lipidData(obj1, obj5, retain_groups = T), regexp = "main effect")
+    expect_error(combine_lipidData(obj3, obj5, retain_groups = T), regexp = "main effect")
+  })
+})
+
+test_that("warnings thrown for duplicate e_data/e_meta identifiers", {
+  expect_warning(combine_lipidData(obj1, obj5), regexp = "Duplicate molecule identifiers")
+  expect_warning(combine_lipidData(obj1, obj2), regexp = "e_meta identifiers")
 })
 
 test_that("attributes correctly stored", {
+  # drop filters and grouping info
   expect_true(all(
     is.null(attr(combn1, "group_DF")),
     length(attr(combn1, "filters")) == 0
   ))
-
-  # drop filters and grouping info
+  
+  expect_true(all(
+    is.null(attr(combn7, "group_DF")),
+    length(attr(combn7, "filters")) == 0
+  ))
+  
+  expect_true(all(
+    is.null(attr(combn5, "group_DF")),
+    length(attr(combn5, "filters")) == 0
+  ))
+  
+  # no filters, keep groups
   expect_true(all(
     !is.null(attr(combn2, "group_DF")),
     length(attr(combn2, "filters")) == 0
   ))
-
-  # no filters, keep groups
+  
   expect_true(all(
     !is.null(attr(combn2, "group_DF")),
     length(attr(combn2, "filters")) == 0
@@ -50,11 +94,29 @@ test_that("attributes correctly stored", {
     length(ftypes) == 2,
     all(ftypes == c("moleculeFilt", "cvFilt"))
   ))
-
-  ftypes <- attr(combn4, "filters") %>%
+  
+  ftypes <- attr(combn6, "filters") %>% 
     lapply(function(x) x$type)
-
+  
+  expect_true(all(
+    is.null(attr(combn6, "group_DF")),
+    length(ftypes) == 1,
+    all(ftypes == c("moleculeFilt"))
+  ))
+  
+  ftypes <- attr(combn8, "filters") %>% 
+    lapply(function(x) x$type)
+  
+  expect_true(all(
+    is.null(attr(combn6, "group_DF")),
+    length(ftypes) == 1,
+    all(ftypes == c("cvFilt"))
+  ))
+  
   # keep both filters and groups
+  ftypes <- attr(combn4, "filters") %>% 
+    lapply(function(x) x$type)
+  
   expect_true(all(
     !is.null(attr(combn4, "group_DF")),
     length(ftypes) == 2,

--- a/tests/testthat/test_combine_omicsData.R
+++ b/tests/testthat/test_combine_omicsData.R
@@ -54,7 +54,7 @@ test_that("bad group/covariate structures throw an error", {
 
 test_that("warnings thrown for duplicate e_data/e_meta identifiers", {
   expect_warning(combine_lipidData(obj1, obj5), regexp = "Duplicate molecule identifiers")
-  expect_warning(combine_lipidData(obj1, obj2), regexp = "e_meta identifiers")
+  expect_warning(combine_lipidData(obj1, obj2), regexp = "molecule identifiers")
 })
 
 test_that("attributes correctly stored", {


### PR DESCRIPTION
reworking combine_lipidData. #175

Functionality is slightly different than I described in the issue:
- f_datas are combined, but if there are duplicate column names then only the ones in the first dataset are kept
- Require that both objects have a grouping structure if the user wants to keep groups.
- Require that covariates and main effects are functionally the same
- I run group_designation on the combined object using the main effects from the _first_ object

Added example to function documentation.

Updated tests.

bump bugfix version.
