### PR TITLE
Ensure grouping is in consistent order to edata cols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pmartR
 Type: Package
 Title: Panomics Marketplace - Quality Control and Statistical Analysis for Panomics Data
-Version: 2.2.0
-Date: 2022-09-30
+Version: 2.2.2
+Date: 2022-10-06
 Authors@R: c(person("Lisa", "Bramer", email = "lisa.bramer@pnnl.gov", role = c("aut", "cre")), person("Kelly", "Stratton", email = "kelly.stratton@pnnl.gov", role = c("aut")))
 Description: Provides functionality for quality control processing and statistical analysis of mass spectrometry (MS) omics data, in particular proteomic (either at the peptide or the protein level), lipidomic, and metabolomic data. This includes data transformation, specification of groups that are to be compared against each other, filtering of features and/or samples, data normalization, data summarization (correlation, PCA), and statistical comparisons between defined groups.
 License: BSD + file LICENSE

--- a/R/seqData_wrappers.R
+++ b/R/seqData_wrappers.R
@@ -905,6 +905,10 @@ voom_wrapper <- function(
 get_group_formula <- function(omicsData){
   
   grouping_info <- get_group_DF(omicsData)
+  e_data_index <- which(colnames(omicsData$e_data) %in% get_edata_cname(omicsData))
+  collist <- colnames(omicsData$e_data[-e_data_index])
+  collist_group <- grouping_info[[get_fdata_cname(omicsData)]]
+  grouping_info <- grouping_info[match(collist_group, collist),]
   
   ## If pairs, add to group_df
   pairs <- attr(grouping_info, "pair_id")

--- a/R/seqData_wrappers.R
+++ b/R/seqData_wrappers.R
@@ -908,7 +908,7 @@ get_group_formula <- function(omicsData){
   e_data_index <- which(colnames(omicsData$e_data) %in% get_edata_cname(omicsData))
   collist <- colnames(omicsData$e_data[-e_data_index])
   collist_group <- grouping_info[[get_fdata_cname(omicsData)]]
-  grouping_info <- grouping_info[match(collist_group, collist),]
+  grouping_info <- grouping_info[match(collist, collist_group),]
   
   ## If pairs, add to group_df
   pairs <- attr(grouping_info, "pair_id")


### PR DESCRIPTION
Can test with this comparison in a mixed up fdata:
get_group_DF(myseqData)[[1]] ## Mixed up
get_group_formula(myseqData)[[1]][[1]] ## Ordered, passed into seqdata functions along with appropriate group formula
colnames(myseqData$e_data)[-1] ## Correct order where first column is IDs