### PR TITLE
fix variable not found bug in summary.customFilt, add unit tests for …'keep mode'

### DIFF
--- a/R/filter_summary.R
+++ b/R/filter_summary.R
@@ -1058,11 +1058,17 @@ summary.customFilt <- function(filter_object){
   # apply the filter #
   filtered_data <- applyFilt(filter_object, omicsData)
   summary_filt <- summary(filtered_data)
-
+  
+  mode_rmv <- !is.null(filter_object$e_data_remove)|
+    !is.null(filter_object$f_data_remove)|
+    !is.null(filter_object$e_meta_remove)
+  
+  mode_kp <- !is.null(filter_object$e_data_keep)|
+    !is.null(filter_object$f_data_keep)|
+    !is.null(filter_object$e_meta_keep)
+  
   #if filter_object contains removes
-  if(!is.null(filter_object$e_data_remove)|
-     !is.null(filter_object$f_data_remove)|
-     !is.null(filter_object$e_meta_remove))
+  if(mode_rmv)
   {
     # samples #
     if(!is.null(filter_object$f_data_remove)) {
@@ -1098,40 +1104,39 @@ summary.customFilt <- function(filter_object){
   }
 
   #if filter_object contains keeps
-  if(!is.null(filter_object$e_data_keep)|
-     !is.null(filter_object$f_data_keep)|
-     !is.null(filter_object$e_meta_keep))
+  # tags of `_left` and `_filt` correspond to items kept and items not kept
+  if(mode_kp)
   {
     # samples #
     if(!is.null(filter_object$f_data_keep)) {
-      samps_keep <- length(filter_object$f_data_keep)
-      samps_discard <- num_samples - samps_keep
+      samps_left <- length(filter_object$f_data_keep)
+      samps_filt <- num_samples - samps_left
     } else {
-      samps_keep <- num_samples
-      samps_discard <- 0
+      samps_left <- num_samples
+      samps_filt <- 0
     }
 
     # e_data #
     if(!is.null(filter_object$e_data_keep)) {
-      edata_keep <- length(filter_object$e_data_keep)
-      edata_discard <- num_edata - edata_keep
+      edata_left <- length(filter_object$e_data_keep)
+      edata_filt <- num_edata - edata_left
     } else {
-      edata_keep <- nrow(filtered_data$e_data)
-      edata_discard <- num_edata - nrow(filtered_data$e_data)
+      edata_left <- nrow(filtered_data$e_data)
+      edata_filt <- num_edata - nrow(filtered_data$e_data)
     }
 
     # e_meta #
     if(!is.null(num_emeta)){
       if(!is.null(filter_object$e_meta_keep)) {
-        emeta_keep <- length(filter_object$e_meta_keep)
-        emeta_discard <- num_emeta - emeta_keep
+        emeta_left <- length(filter_object$e_meta_keep)
+        emeta_filt <- num_emeta - emeta_left
       } else {
-        emeta_keep <- length(unique(filtered_data$e_meta[, emeta_id] ))
-        emeta_discard <- num_emeta - length(unique(filtered_data$e_meta[, emeta_id] ))
+        emeta_left <- length(unique(filtered_data$e_meta[, emeta_id] ))
+        emeta_filt <- num_emeta - length(unique(filtered_data$e_meta[, emeta_id] ))
       }
     }
 
-    disp_colnames <- c("Kept", "Discarded", "Total")
+    disp_colnames <- c("Discarded", "Kept", "Total")
 
   }
   

--- a/tests/testthat/test_summary_filter.R
+++ b/tests/testthat/test_summary_filter.R
@@ -312,7 +312,10 @@ test_that('the filter object summaries are all square',{
   )
 
   # Custom filter ---------------
-
+  
+  ## Test with remove arguments
+  
+  # remove e_data
   expect_equal(
     summary(custom_filter(pdata, e_data_remove = "1406")),
     structure(
@@ -327,7 +330,8 @@ test_that('the filter object summaries are all square',{
                     "Proteins (e_meta)")
     )
   )
-
+  
+  # remove f_data
   expect_equal(
     summary(custom_filter(pdata, f_data_remove = "Infection4")),
     structure(
@@ -343,6 +347,7 @@ test_that('the filter object summaries are all square',{
     )
   )
 
+  # remove e_meta
   expect_equal(
     summary(custom_filter(pdata, e_meta_remove = "ALBU_HUMAN")),
     structure(
@@ -357,5 +362,113 @@ test_that('the filter object summaries are all square',{
                     "Proteins (e_meta)")
     )
   )
-
+  
+  # combination
+  expect_equal(
+    summary(
+      custom_filter(
+        pdata, 
+        e_data_remove = "6948840",
+        f_data_remove = "Mock2",
+        e_meta_remove = "COR1C_HUMAN"
+      )
+    ),
+    structure(
+      data.frame(
+        Filtered = c(1, 1, 1),
+        Remaining = c(11, 149, 82),
+        Total = c(12, 150, 83)
+      ),
+      names = c("Filtered", "Remaining", "Total"),
+      class = c("customFilterSummary", "data.frame"),
+      row.names = c("SampleIDs (f_data)", "Mass_Tag_IDs (e_data)",
+                    "Proteins (e_meta)")
+    )
+  )
+  
+  ## Test with keep arguments
+  
+  # e_meta keep
+  expect_equal(
+    summary(
+      custom_filter(
+        pdata, e_meta_keep = c("ALBU_HUMAN",  "RL40_HUMAN",  "ALBU_HUMAN")
+      )
+    ),
+    structure(
+      data.frame(
+        Discarded = c(0, 141, 80),
+        Kept = c(12, 9, 3),
+        Total = c(12, 150, 83)
+      ),
+      names = c("Discarded", "Kept", "Total"),
+      class = c("customFilterSummary", "data.frame"),
+      row.names = c("SampleIDs (f_data)", "Mass_Tag_IDs (e_data)",
+                    "Proteins (e_meta)")
+    )
+  )
+  
+  # f_data keep
+  expect_equal(
+    summary(
+      custom_filter(
+        pdata, f_data_keep = c("Infection1", "Infection2", "Mock1", "Mock2", "Mock3")
+      )
+    ),
+    structure(
+      data.frame(
+        Discarded = c(7, 0, 0),
+        Kept = c(5, 150, 83),
+        Total = c(12, 150, 83)
+      ),
+      names = c("Discarded", "Kept", "Total"),
+      class = c("customFilterSummary", "data.frame"),
+      row.names = c("SampleIDs (f_data)", "Mass_Tag_IDs (e_data)",
+                    "Proteins (e_meta)")
+    )
+  )
+  
+  # e_data keep
+  expect_equal(
+    summary(
+      custom_filter(
+        pdata, 
+        e_data_keep = c("1024",  "4198254",  "6637724", "216191"),
+        f_data_keep = c("Infection1", "Infection2", "Mock1", "Mock2", "Mock3"),
+        e_meta_keep = c("ALBU_HUMAN",  "RL40_HUMAN",  "ALBU_HUMAN")
+      )
+    ),
+    structure(
+      data.frame(
+        Discarded = c(7, 146, 80),
+        Kept = c(5, 4, 3),
+        Total = c(12, 150, 83)
+      ),
+      names = c("Discarded", "Kept", "Total"),
+      class = c("customFilterSummary", "data.frame"),
+      row.names = c("SampleIDs (f_data)", "Mass_Tag_IDs (e_data)",
+                    "Proteins (e_meta)")
+    )
+  )
+  
+  # combination
+  expect_equal(
+    summary(
+      custom_filter(
+        pdata, e_data_keep = c("1024",  "4198254",  "6637724", "216191")
+      )
+    ),
+    structure(
+      data.frame(
+        Discarded = c(0, 146, 79),
+        Kept = c(12, 4, 4),
+        Total = c(12, 150, 83)
+      ),
+      names = c("Discarded", "Kept", "Total"),
+      class = c("customFilterSummary", "data.frame"),
+      row.names = c("SampleIDs (f_data)", "Mass_Tag_IDs (e_data)",
+                    "Proteins (e_meta)")
+    )
+  )
+  
 })


### PR DESCRIPTION
Some changes got introduced in a merge that caused summary.customFilt to not find a variable.

Changed summary.customFilt to only have variables with postfixes '_filt' and '_left' so that they can both be referenced at the end of the function.  Changed the order of the summary names when in "keep" mode from c("Kept", "Discarded", "Total") to c("Discarded", "Kept", "Total").