### PR TITLE
Feature/gha manual workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,6 +36,6 @@ jobs:
         env:
           '_R_CHECK_LIMIT_CORES_': 'warn'
         with:
-          args: 'c("--no-manual")'
-          build_args: 'c("--no-manual")'
+          args: 'c("--no-manual", "--no-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
           error-on: '"error"'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,11 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  workflow_dispatch:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master, develop]
+    branches: [master]
 
 name: R-CMD-check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [master]
-  pull_request:
     branches: [master, develop]
+  pull_request:
+    branches: [master]
   release:
     types: [published]
   workflow_dispatch:
@@ -45,7 +45,9 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        if: |
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           clean: false


### PR DESCRIPTION
- Run github pages building on pushes to both master and develop, but only deploy the website on pushes to master
- skip vignette building in R-CMD-Check - reduces build time by a ton, vignettes are still checked by pkgdown
- Add manually triggered runs (requires merge to master).  Do not run workflows on PR's to develop, only on successful merges or manually triggered runs.