### PR TITLE
Bugfix/purrr emeta cname

### DIFF
--- a/R/as.omicsData.R
+++ b/R/as.omicsData.R
@@ -141,8 +141,7 @@ as.isobaricpepData <- function (e_data, f_data, e_meta = NULL, edata_cname,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -318,8 +317,7 @@ as.lipidData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -488,8 +486,7 @@ as.metabData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -664,8 +661,7 @@ as.nmrData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -844,8 +840,7 @@ as.pepData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -1015,8 +1010,7 @@ as.proData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,
@@ -1200,8 +1194,7 @@ as.seqData <- function (e_data, f_data, e_meta = NULL,
   # Remove the emeta_cname element from the res list. That way only the e_data,
   # f_data, and e_meta (when applicable) data frames will be part of the output.
   # emeta_cname will no longer be an element of and omicsData object.
-  res <- res %>%
-    purrr::list_modify("emeta_cname" = NULL)
+  res <- res[-which(names(res) == "emeta_cname")]
   
   # set column name attributes #
   attr(res, "cnames") = list(edata_cname = edata_cname,

--- a/tests/testthat/test_as_isobaricpepData.R
+++ b/tests/testthat/test_as_isobaricpepData.R
@@ -19,6 +19,9 @@ test_that('as.isobaricpepData returns the correct data frame and attributes',{
                                 fdata_cname = 'Sample',
                                 emeta_cname = 'Protein')
   
+  # Check high level structure
+  expect_equal(names(isodata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(isodata$e_data),
                c(150, 13))
@@ -87,6 +90,9 @@ test_that('as.isobaricpepData returns the correct data frame and attributes',{
                                 fdata_cname = 'Sample',
                                 emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(isodata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(isodata$e_data),
@@ -185,6 +191,9 @@ test_that('as.isobaricpepData returns the correct data frame and attributes',{
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(isodata), c("e_data", "f_data", "e_meta"))
+  
   # Check the dimensions of the e_data and f_data data frames.
   expect_equal(dim(isodata$e_data),
                c(150, 13))
@@ -255,6 +264,9 @@ test_that('as.isobaricpepData returns the correct data frame and attributes',{
                  paste('Extra peptides were found in e_meta that were not in',
                        'e_data. These have been removed from e_meta.',
                        sep = ' '))
+  
+  # Check high level structure
+  expect_equal(names(isodata), c("e_data", "f_data", "e_meta"))
   
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(isodata$e_data),
@@ -343,6 +355,9 @@ test_that('as.isobaricpepData returns the correct data frame and attributes',{
                                 edata_cname = 'Peptide',
                                 fdata_cname = 'Sample',
                                 emeta_cname = 'Protein')
+  
+  # Check high level structure
+  expect_equal(names(isodata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(isodata$e_data),

--- a/tests/testthat/test_as_lipidData.R
+++ b/tests/testthat/test_as_lipidData.R
@@ -18,6 +18,9 @@ test_that('as.lipidData returns the correct data frame and attributes',{
                         fdata_cname = 'Sample_Name',
                         emeta_cname = 'LipidClass')
   
+  # Check high level structure
+  expect_equal(names(ldata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(ldata$e_data),
                c(146, 12))
@@ -76,6 +79,9 @@ test_that('as.lipidData returns the correct data frame and attributes',{
                                        fdata_cname = 'Sample_Name',
                                        emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(ldata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(ldata$e_data),
@@ -161,6 +167,9 @@ test_that('as.lipidData returns the correct data frame and attributes',{
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(ldata), c("e_data", "f_data", "e_meta"))
+  
   # Confirm the dimensions of the e_data and f_data data frames.
   expect_equal(dim(ldata$e_data),
                c(146, 12))
@@ -222,6 +231,9 @@ test_that('as.lipidData returns the correct data frame and attributes',{
                  paste('Extra lipids were found in e_meta that were not in',
                        'e_data. These have been removed from e_meta.',
                        sep = ' '))
+  
+  # Check high level structure
+  expect_equal(names(ldata), c("e_data", "f_data", "e_meta"))
   
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(ldata$e_data),
@@ -297,6 +309,9 @@ test_that('as.lipidData returns the correct data frame and attributes',{
                       f_data = fdata,
                       edata_cname = 'LipidCommonName',
                       fdata_cname = 'Sample_Name')
+  
+  # Check high level structure
+  expect_equal(names(ldata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(ldata$e_data),

--- a/tests/testthat/test_as_metabData.R
+++ b/tests/testthat/test_as_metabData.R
@@ -18,6 +18,9 @@ test_that('as.metabData returns the correct data frame and attributes',{
                         fdata_cname = 'SampleID',
                         emeta_cname = 'MClass')
   
+  # Check high level structure
+  expect_equal(names(mdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(mdata$e_data),
                c(80, 13))
@@ -76,6 +79,9 @@ test_that('as.metabData returns the correct data frame and attributes',{
                                        fdata_cname = 'SampleID',
                                        emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(mdata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(mdata$e_data),
@@ -161,6 +167,9 @@ test_that('as.metabData returns the correct data frame and attributes',{
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(mdata), c("e_data", "f_data", "e_meta"))
+  
   # Confirm the dimensions of the e_data and f_data data frames.
   expect_equal(dim(mdata$e_data),
                c(80, 13))
@@ -222,6 +231,9 @@ test_that('as.metabData returns the correct data frame and attributes',{
                  paste('Extra metabolites were found in e_meta that were not in',
                        'e_data. These have been removed from e_meta.',
                        sep = ' '))
+  
+  # Check high level structure
+  expect_equal(names(mdata), c("e_data", "f_data", "e_meta"))
   
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(mdata$e_data),
@@ -297,6 +309,9 @@ test_that('as.metabData returns the correct data frame and attributes',{
                         f_data = fdata,
                         edata_cname = 'Metabolite',
                         fdata_cname = 'SampleID')
+  
+  # Check high level structure
+  expect_equal(names(mdata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(mdata$e_data),

--- a/tests/testthat/test_as_nmrData.R
+++ b/tests/testthat/test_as_nmrData.R
@@ -18,6 +18,9 @@ test_that('as.nmrData returns the correct data frame and attributes',{
                         fdata_cname = 'SampleID',
                         emeta_cname = 'nmrClass')
   
+  # Check high level structure
+  expect_equal(names(nmrdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(nmrdata$e_data),
                c(38, 42))
@@ -83,6 +86,9 @@ test_that('as.nmrData returns the correct data frame and attributes',{
                                        fdata_cname = 'SampleID',
                                        emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(nmrdata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(nmrdata$e_data),
@@ -174,6 +180,9 @@ test_that('as.nmrData returns the correct data frame and attributes',{
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(nmrdata), c("e_data", "f_data", "e_meta"))
+  
   # Confirm the dimensions of the e_data and f_data data frames.
   expect_equal(dim(nmrdata$e_data),
                c(38, 42))
@@ -242,6 +251,9 @@ test_that('as.nmrData returns the correct data frame and attributes',{
                  paste('Extra metabolites were found in e_meta that were not',
                        'in e_data. These have been removed from e_meta.',
                        sep = ' '))
+  
+  # Check high level structure
+  expect_equal(names(nmrdata), c("e_data", "f_data", "e_meta"))
   
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(nmrdata$e_data),
@@ -324,6 +336,9 @@ test_that('as.nmrData returns the correct data frame and attributes',{
                         f_data = fdata,
                         edata_cname = 'Metabolite',
                         fdata_cname = 'SampleID')
+  
+  # Check high level structure
+  expect_equal(names(nmrdata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(nmrdata$e_data),

--- a/tests/testthat/test_as_pepData.R
+++ b/tests/testthat/test_as_pepData.R
@@ -18,6 +18,9 @@ test_that('as.pepData returns the correct data frame and attributes',{
                       fdata_cname = 'SampleID',
                       emeta_cname = 'Protein')
 
+  # Check high level structure
+  expect_equal(names(pdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(pdata$e_data),
                c(150, 13))
@@ -77,6 +80,9 @@ test_that('as.pepData returns the correct data frame and attributes',{
                                      fdata_cname = 'SampleID',
                                      emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(pdata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(pdata$e_data),
@@ -164,7 +170,10 @@ test_that('as.pepData returns the correct data frame and attributes',{
                  paste("Extra samples were found in f_data that were not in",
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
-
+  
+  # Check high level structure
+  expect_equal(names(pdata), c("e_data", "f_data", "e_meta"))
+  
   # Check the dimensions of the e_data and f_data data frames.
   expect_equal(dim(pdata$e_data),
                c(150, 13))
@@ -227,6 +236,9 @@ test_that('as.pepData returns the correct data frame and attributes',{
                        'e_data. These have been removed from e_meta.',
                        sep = ' '))
 
+  # Check high level structure
+  expect_equal(names(pdata), c("e_data", "f_data", "e_meta"))
+  
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(pdata$e_data),
                c(117, 13))
@@ -306,6 +318,9 @@ test_that('as.pepData returns the correct data frame and attributes',{
                       fdata_cname = 'SampleID',
                       emeta_cname = 'Protein')
 
+  # Check high level structure
+  expect_equal(names(pdata), c("e_data", "f_data", "e_meta"))
+  
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(pdata$e_data),
                c(150, 13))

--- a/tests/testthat/test_as_proData.R
+++ b/tests/testthat/test_as_proData.R
@@ -18,6 +18,9 @@ test_that('as.proData returns the correct data frame and attributes',{
                        fdata_cname = 'SampleID',
                        emeta_cname = 'PClass')
   
+  # Check high level structure
+  expect_equal(names(prdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(prdata$e_data),
                c(150, 12))
@@ -79,6 +82,9 @@ test_that('as.proData returns the correct data frame and attributes',{
                                       fdata_cname = 'SampleID',
                                       emeta_cname = 'Test'),
                  "emeta_cname set to NULL, no e_meta object was provided.")
+  
+  # Check high level structure
+  expect_equal(names(prdata), c("e_data", "f_data", "e_meta"))
   
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(prdata$e_data),
@@ -167,6 +173,9 @@ test_that('as.proData returns the correct data frame and attributes',{
                        "e_data. These have been removed from f_data.",
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(prdata), c("e_data", "f_data", "e_meta"))
+  
   # Confirm the dimensions of the e_data and f_data data frames.
   expect_equal(dim(prdata$e_data),
                c(150, 12))
@@ -231,6 +240,9 @@ test_that('as.proData returns the correct data frame and attributes',{
                  paste('Extra proteins were found in e_meta that were not in',
                        'e_data. These have been removed from e_meta.',
                        sep = ' '))
+  
+  # Check high level structure
+  expect_equal(names(prdata), c("e_data", "f_data", "e_meta"))
   
   # Confirm the dimensions of the e_data and e_meta data frames.
   expect_equal(dim(prdata$e_data),
@@ -309,6 +321,9 @@ test_that('as.proData returns the correct data frame and attributes',{
                        f_data = fdata,
                        edata_cname = 'Reference',
                        fdata_cname = 'SampleID')
+  
+  # Check high level structure
+  expect_equal(names(prdata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(prdata$e_data),

--- a/tests/testthat/test_as_seqData.R
+++ b/tests/testthat/test_as_seqData.R
@@ -20,6 +20,9 @@ test_that('as.seqData returns the correct data frame and attributes',{
                       fdata_cname = 'Samples'
                       )
   
+  # Check high level structure
+  expect_equal(names(seqdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(seqdata$e_data), c(1200, 41))
   expect_equal(dim(seqdata$f_data), c(40, 4))
@@ -137,6 +140,9 @@ test_that('as.seqData returns the correct data frame and attributes',{
                        'e_data. These have been removed from f_data.',
                        sep = ' '))
   
+  # Check high level structure
+  expect_equal(names(seqdata), c("e_data", "f_data", "e_meta"))
+  
   # Ensure the returned data frames are the correct dimension.
   expect_equal(dim(seqdata$e_data), c(1200, 41))
   expect_equal(dim(seqdata$f_data), c(40, 4))
@@ -249,6 +255,9 @@ test_that('as.seqData returns the correct data frame and attributes',{
                       edata_cname = 'ID_REF',
                       fdata_cname = 'Samples'
                       )
+  
+  # Check high level structure
+  expect_equal(names(seqdata), c("e_data", "f_data", "e_meta"))
   
   # Verify that the returned data frames are the correct dimension.
   expect_equal(dim(seqdata$e_data), c(1200, 41))


### PR DESCRIPTION
Change removal of 'e_meta_cname' from `pre_flight` output to use brackets so purrr version doesn't affect the object output.

Add some simple names tests to all the object constructors.

Closes #241 