### PR TITLE
fix bad alignment of sample ID's in nonmissing_per_group and ppp_rip

### DIFF
--- a/R/nonmissing_per_group.R
+++ b/R/nonmissing_per_group.R
@@ -42,12 +42,16 @@ nonmissing_per_group <- function (omicsData) {
   # Reorder the samples. This is done because the C++ function for counting
   # group sizes assumes the samples are ordered by group in the omicsData data
   # frames.
-  group_dat <- as.character(groupDF$Group[order(groupDF$Group)])
+
+  # match the order of the groupDF$SampleID to the order of the columns in edata
+  samp_ord = match(groupDF[,get_fdata_cname(omicsData)], colnames(edata))
+  group_ord = order(groupDF$Group)
+  group_dat <- as.character(groupDF$Group[group_ord])
 
   # Reorder the columns of e_data. This needs to be done so the e_data columns
   # will match the order of the group_data vector. These are ordered because the
   # following C++ function assumes the samples are in order.
-  edata <- edata[, order(groupDF$Group)]
+  edata <- edata[, samp_ord[group_ord]]
 
   # Count the number of nonmissing values per group. The output is a matrix with
   # the number of observations down the rows and the number of unique groups

--- a/R/subset_funcs.R
+++ b/R/subset_funcs.R
@@ -191,9 +191,9 @@ ppp_rip <- function(e_data, edata_id, fdata_id, groupDF, alpha=0.2, proportion=0
   mydata <- e_data[inds, -edata_id_ind]
   peps <- peps[inds]
   
-  #added 2/6/17 lines 223-231 iobani
-  group_dat = as.character(groupDF$Group[order(groupDF$Group)])
-  mydata = mydata[, order(groupDF$Group)]
+  # make sure groups are aligned with the columns of e_data
+  reorder = match(colnames(mydata), as.character(groupDF[,fdata_id]))
+  group_dat = as.character(groupDF[reorder,]$Group)
   
   # conduct K-W test using kw_rcpp function 
   pvals = kw_rcpp(as.matrix(mydata), group_dat)

--- a/src/kw_rcpp.cpp
+++ b/src/kw_rcpp.cpp
@@ -8,13 +8,6 @@ are stored in another vector called rankvec. The ranks are used in the
 calculation of the Kruskall Wallis h statistic to then calculate the p-value of 
 that specific row.*/
 
-/*The fuction group_size takes one input, a vector of strings called group. This
-vector is an ordered character vector indicating what "group" factor level a 
-specific data element belongs to. This function makes a copy of group, called temp.
-Next a unique function is applied to temp, exposing the levels of the factor. 
-Next we iterate through temp and count how many elements belong to each level, 
-these counts are stored in gsize.*/
-
 /*The function calculate_kwh takes two inputs, a vector of ranks and a vector 
 of the number of non-NA values per group.This function implements the 
 mathematical formula for Kruskal Wallis test statistic. It returns a numeric 
@@ -24,8 +17,7 @@ value(p-value).*/
 and computes a p-value.*/
 
 /*The main function is the kwh function, it takes two inputs, an armadillo 
-matrix and a vector of strings called "group". The vector "group" is fed to
-the group_size function which will return a vector of group sizes. One row 
+matrix and a vector of strings called "group".  One row 
 of the armadillo matrix is stored in a vector named "cp". We iterate over
 "cp" and collect all non-NA values and store them in a vector of vectors
 called "groups". We iterate over "groups" and take the size of each group 
@@ -47,32 +39,6 @@ matrix is reached, all the p-values are stored in order in a list named
 // [[Rcpp::depends(RcppArmadillo)]]
 // [[Rcpp::depends(BH)]]
 using namespace Rcpp;
-
-std::vector<int> gp_size(std::vector<std::string> group)
-{
-  std::vector<std::string> temp;
-  temp = group;
-  
-  //std::sort(temp.begin(),temp.end());
-  
-  temp.erase( std::unique( temp.begin(), temp.end() ), temp.end() );
-  int tempsize = 0;
-  
-  tempsize = temp.size();
-  
-  std::vector<int> gsize(tempsize);
-  
-  for(unsigned int i = 0;i<group.size();i++)
-  {
-    for(unsigned int k=0;k<temp.size();k++)
-    {
-      if(group[i]==temp[k])
-        gsize[k]++;
-    }
-  }
-  
-  return gsize;
-}
 
 double calculate_kwh(std::vector <std::vector <double> > ranks, std::vector <double> nonmiss_sizes)
 {


### PR DESCRIPTION
Closes #253 

In nonmissing_per_group, we re-align the groups to be contiguous (e.g. "A", "A", "B", "B"), and also re-align the edata column names to the new group alignment.

In kw_rcpp, we just re-align the groups to match the column names of edata, this is because I changed kw_rcpp a while ago to handle non-contiguous groups, and the only requirement is that the groups align with the column names of edata.

