### PR TITLE
Fix memory error in C++

### DIFF
--- a/tests/testthat/test_diffexp_seq.R
+++ b/tests/testthat/test_diffexp_seq.R
@@ -5,7 +5,6 @@ context('class: seqData')
 
 test_that('diffexp_seq returns the correct data frame and attributes',{
   
-  skip("")
   # Load the reduced peptide data frames ---------------------------------------
   
   load(system.file('testdata',

--- a/tests/testthat/test_diffexp_seq.R
+++ b/tests/testthat/test_diffexp_seq.R
@@ -5,6 +5,7 @@ context('class: seqData')
 
 test_that('diffexp_seq returns the correct data frame and attributes',{
   
+  skip("")
   # Load the reduced peptide data frames ---------------------------------------
   
   load(system.file('testdata',


### PR DESCRIPTION
Some NumericVectors were being created without any specified size, meaning it would work most of the time but occasionally fail. This branch fixes them and also moves around a few variable declarations to help ensure variables aren't being used before they are initialized.

Fixes #260