### PR TITLE
updates for robustbase 0.99

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pmartR
 Type: Package
 Title: Panomics Marketplace - Quality Control and Statistical Analysis for Panomics Data
-Version: 2.3.2
-Date: 2023-05-23
+Version: 2.4.0
+Date: 2023-06-28
 Authors@R: c(person("Lisa", "Bramer", email = "lisa.bramer@pnnl.gov", role = c("aut", "cre")), person("Kelly", "Stratton", email = "kelly.stratton@pnnl.gov", role = c("aut")))
 Description: Provides functionality for quality control processing and statistical analysis of mass spectrometry (MS) omics data, in particular proteomic (either at the peptide or the protein level), lipidomic, and metabolomic data. This includes data transformation, specification of groups that are to be compared against each other, filtering of features and/or samples, data normalization, data summarization (correlation, PCA), and statistical comparisons between defined groups.
 License: BSD + file LICENSE

--- a/tests/testthat/_snaps/plots/plot-rmdfilt.svg
+++ b/tests/testthat/_snaps/plots/plot-rmdfilt.svg
@@ -21,68 +21,65 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzAuODN8NjM2LjU3fDM4LjgzfDUxNC44Mw=='>
-    <rect x='30.83' y='38.83' width='605.74' height='476.00' />
+  <clipPath id='cpMjcuOTB8NjM2LjU3fDM4LjgzfDUxNC44Mw=='>
+    <rect x='27.90' y='38.83' width='608.67' height='476.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzAuODN8NjM2LjU3fDM4LjgzfDUxNC44Mw==)'>
-<rect x='30.83' y='38.83' width='605.74' height='476.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='30.83,426.63 636.57,426.63 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,280.95 636.57,280.95 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,135.27 636.57,135.27 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,499.47 636.57,499.47 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,353.79 636.57,353.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,208.11 636.57,208.11 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='30.83,62.43 636.57,62.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='60.62,514.83 60.62,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='110.27,514.83 110.27,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='159.92,514.83 159.92,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='209.57,514.83 209.57,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.22,514.83 259.22,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='308.88,514.83 308.88,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='358.53,514.83 358.53,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='408.18,514.83 408.18,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='457.83,514.83 457.83,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='507.48,514.83 507.48,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='557.13,514.83 557.13,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='606.78,514.83 606.78,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<circle cx='507.48' cy='261.40' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
-<circle cx='557.13' cy='286.31' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
-<circle cx='606.78' cy='221.49' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
-<circle cx='60.62' cy='194.59' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='110.27' cy='447.26' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='159.92' cy='262.58' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='209.57' cy='493.20' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='259.22' cy='60.47' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
-<circle cx='308.88' cy='317.16' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='358.53' cy='286.55' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='408.18' cy='158.90' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<circle cx='457.83' cy='372.85' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
-<line x1='30.83' y1='98.56' x2='636.57' y2='98.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='30.83' y='38.83' width='605.74' height='476.00' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjcuOTB8NjM2LjU3fDM4LjgzfDUxNC44Mw==)'>
+<rect x='27.90' y='38.83' width='608.67' height='476.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='27.90,454.49 636.57,454.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='27.90,308.81 636.57,308.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='27.90,163.13 636.57,163.13 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='27.90,381.65 636.57,381.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='27.90,235.97 636.57,235.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='27.90,90.29 636.57,90.29 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='57.83,514.83 57.83,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='107.73,514.83 107.73,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='157.62,514.83 157.62,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='207.51,514.83 207.51,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='257.40,514.83 257.40,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='307.29,514.83 307.29,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='357.18,514.83 357.18,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='407.07,514.83 407.07,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='456.97,514.83 456.97,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='506.86,514.83 506.86,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='556.75,514.83 556.75,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='606.64,514.83 606.64,38.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='506.86' cy='261.40' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
+<circle cx='556.75' cy='286.31' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
+<circle cx='606.64' cy='221.49' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #00BFC4; fill-opacity: 0.50;' />
+<circle cx='57.83' cy='194.59' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='107.73' cy='447.26' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='157.62' cy='262.58' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='207.51' cy='493.20' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='257.40' cy='60.47' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='307.29' cy='317.16' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='357.18' cy='286.55' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='407.07' cy='158.90' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<circle cx='456.97' cy='372.85' r='3.56' style='stroke-width: 0.71; stroke: none; fill: #F8766D; fill-opacity: 0.50;' />
+<line x1='27.90' y1='126.42' x2='636.57' y2='126.42' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='27.90' y='38.83' width='608.67' height='476.00' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='25.90' y='502.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
-<text x='25.90' y='356.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='25.90' y='211.14' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='25.90' y='65.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<polyline points='28.09,499.47 30.83,499.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,353.79 30.83,353.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,208.11 30.83,208.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,62.43 30.83,62.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(66.68,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection1</text>
-<text transform='translate(116.33,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection2</text>
-<text transform='translate(165.98,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection3</text>
-<text transform='translate(215.63,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection4</text>
-<text transform='translate(265.28,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection5</text>
-<text transform='translate(314.93,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection6</text>
-<text transform='translate(364.58,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection7</text>
-<text transform='translate(414.23,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection8</text>
-<text transform='translate(463.89,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection9</text>
-<text transform='translate(513.54,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock1</text>
-<text transform='translate(563.19,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock2</text>
-<text transform='translate(612.84,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock3</text>
-<text x='333.70' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='42.81px' lengthAdjust='spacingAndGlyphs'>Samples</text>
+<text x='22.97' y='384.68' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.97' y='239.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='22.97' y='93.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='25.16,381.65 27.90,381.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,235.97 27.90,235.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,90.29 27.90,90.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text transform='translate(63.89,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection1</text>
+<text transform='translate(113.78,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection2</text>
+<text transform='translate(163.67,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection3</text>
+<text transform='translate(213.56,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection4</text>
+<text transform='translate(263.46,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection5</text>
+<text transform='translate(313.35,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection6</text>
+<text transform='translate(363.24,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection7</text>
+<text transform='translate(413.13,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection8</text>
+<text transform='translate(463.02,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='38.16px' lengthAdjust='spacingAndGlyphs'>Infection9</text>
+<text transform='translate(512.91,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock1</text>
+<text transform='translate(562.80,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock2</text>
+<text transform='translate(612.70,519.76) rotate(-90)' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>Mock3</text>
+<text x='332.24' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='42.81px' lengthAdjust='spacingAndGlyphs'>Samples</text>
 <text transform='translate(13.05,276.83) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='174.29px' lengthAdjust='spacingAndGlyphs'>log2(Robust Mahalanobis Distance)</text>
 <rect x='647.53' y='246.41' width='66.99' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='653.01' y='260.60' style='font-size: 11.00px; font-family: sans;' textLength='30.58px' lengthAdjust='spacingAndGlyphs'>Group</text>
@@ -92,7 +89,7 @@
 <circle cx='661.65' cy='293.14' r='3.56' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <text x='675.77' y='278.89' style='font-size: 8.80px; font-family: sans;' textLength='33.27px' lengthAdjust='spacingAndGlyphs'>Infection</text>
 <text x='675.77' y='296.17' style='font-size: 8.80px; font-family: sans;' textLength='21.04px' lengthAdjust='spacingAndGlyphs'>Mock</text>
-<text x='30.83' y='31.07' style='font-size: 11.00px; font-style: italic; font-family: sans;' textLength='121.40px' lengthAdjust='spacingAndGlyphs'>p-value threshold =  0.01</text>
-<text x='30.83' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='143.19px' lengthAdjust='spacingAndGlyphs'>Sample Outlier Results</text>
+<text x='27.90' y='31.07' style='font-size: 11.00px; font-style: italic; font-family: sans;' textLength='121.40px' lengthAdjust='spacingAndGlyphs'>p-value threshold =  0.01</text>
+<text x='27.90' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='143.19px' lengthAdjust='spacingAndGlyphs'>Sample Outlier Results</text>
 </g>
 </svg>

--- a/tests/testthat/test_filter_rmd.R
+++ b/tests/testthat/test_filter_rmd.R
@@ -77,11 +77,11 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_equal(dim(pfilter_rmd),
                c(12, 9))
   expect_equal(round(pfilter_rmd$Log2.md, 3),
-               c(1.754, 1.983, 1.340, 2.158, 0.635, 1.697,
-                 4.748, 2.210, 2.131, 0.787, 0.374, 1.477))
+               c(1.881, 2.11, 1.467, 2.284, 0.762, 1.823, 4.874, 2.337, 2.258, 
+                 0.914, 0.501, 1.604))
   expect_equal(round(pfilter_rmd$pvalue, 3),
-               c(0.643, 0.556, 0.772, 0.485, 0.907, 0.663,
-                 0.000, 0.463, 0.496, 0.886, 0.935, 0.733))
+               c(0.596, 0.505, 0.736, 0.432, 0.889, 0.618, 0, 0.41, 0.443, 
+                 0.865, 0.923, 0.694))
   expect_equal(round(pfilter_rmd$MAD, 3),
                c(1.331, 1.185, 1.241, 1.228, 1.228, 1.324,
                  1.203, 1.081, 1.169, 1.142, 1.274, 1.245))
@@ -153,18 +153,17 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_equal(dim(nmrfilter_rmd),
                c(41, 8))
   expect_equal(round(nmrfilter_rmd$Log2.md, 3),
-
-               c(3.913, 2.919, 0.785, 3.937, 5.23, 0.897, 1.553, 1.644, 1.447,
-                 2.126, 1.36, 1.995, 1.256, 0.095, 1.066, 0.999, 2.728, 1.966,
-                 1.471, 3.022, 2.122, -1.172, 4.629, 2.262, 5.708, 3.163, 4.236,
-                 1.666, 2.165, 1.107, 2.833, 2.18, 0.1, 0.131, 1.718, 1.712,
-                 1.757, 3.113, 1.832, 2.577, 2.01))
+               c(4.288, 3.294, 1.161, 4.312, 5.605, 1.273, 1.928, 2.019, 1.822, 
+                 2.501, 1.736, 2.371, 1.632, 0.47, 1.441, 1.375, 3.104, 2.342, 
+                 1.846, 3.397, 2.498, -0.797, 5.005, 2.638, 6.083, 3.539, 4.611, 
+                 2.041, 2.541, 1.482, 3.208, 2.555, 0.476, 0.507, 2.093, 2.087, 
+                 2.132, 3.489, 2.207, 2.953, 2.385))
   expect_equal(round(nmrfilter_rmd$pvalue, 3),
-               c(0.005, 0.109, 0.786, 0.004, 0, 0.761, 0.569, 0.537, 0.605,
-                 0.359, 0.633, 0.408, 0.665, 0.899, 0.719, 0.736, 0.157, 0.419,
-                 0.597, 0.087, 0.36, 0.979, 0, 0.309, 0, 0.062, 0.001, 0.529,
-                 0.344, 0.708, 0.13, 0.339, 0.899, 0.895, 0.511, 0.513, 0.496,
-                 0.07, 0.469, 0.202, 0.402))
+               c(0.001, 0.044, 0.692, 0.001, 0, 0.66, 0.433, 0.399, 0.472, 0.226, 
+                 0.504, 0.27, 0.541, 0.847, 0.606, 0.628, 0.072, 0.28, 0.464, 
+                 0.032, 0.227, 0.966, 0, 0.183, 0, 0.02, 0, 0.39, 0.213, 0.593, 
+                 0.055, 0.208, 0.846, 0.841, 0.371, 0.373, 0.357, 0.024, 0.329, 
+                 0.102, 0.265))
   expect_equal(round(nmrfilter_rmd$MAD, 3),
                c(0.922, 0.978, 1.411, 0.951, 1.047, 1.173, 1.245, 1.271, 1.176,
                  1.365, 1.234, 1.26, 1.27, 1.463, 1.461, 1.39, 1.328, 1.435,
@@ -226,8 +225,7 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_equal(dim(pfilter_rmd_sg),
                c(9, 9))
   expect_equal(round(pfilter_rmd_sg$Log2.md, 3),
-               c(6.321, 6.015, 6.225, 6.321, 5.608,
-                 5.976, 8.923, 6.132, 6.380))
+               c(6.5, 6.195, 6.404, 6.5, 5.788, 6.156, 9.102, 6.311, 6.56))
   expect_equal(round(pfilter_rmd_sg$pvalue, 16),
                c(9.000000e-16, 1.299400e-12, 1.030000e-14, 9.000000e-16,
                  2.459952e-09, 2.959300e-12, 0.000000e+00, 9.600000e-14,
@@ -274,12 +272,12 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_equal(dim(pfilter_rmd_sg_f),
                c(10, 9))
   expect_equal(round(pfilter_rmd_sg_f$Log2.md, 3),
-               c(2.292, 0.680, 1.661, 0.385, 1.255,
-                 2.047, 1.655, 2.474, 2.772, 5.614))
+               c(2.451, 0.838, 1.819, 0.544, 1.414, 2.205, 1.813, 2.632, 2.931, 
+                 5.773))
   expect_equal(round(pfilter_rmd_sg_f$pvalue, 10),
-               c(0.4285077890, 0.9010201653, 0.6750442797, 0.9343177198,
-                 0.7934655431, 0.5305775013, 0.6770948538, 0.3520673347,
-                 0.2333855866, 0.0000000022))
+               c(0.3616019649, 0.877622914, 0.6189490715, 0.9178949096, 0.7516195837, 
+                 0.4650147929, 0.6211961737, 0.2872941484, 0.1780398691, 2e-10
+               ))
   expect_equal(round(pfilter_rmd_sg_f$MAD, 3),
                c(1.331, 1.185, 1.241, 1.228, 1.228,
                  1.324, 1.203, 1.081, 1.169, 1.142))
@@ -401,7 +399,7 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_identical(attr(nmrfiltered, "filters")[[1]]$threshold,
                    0.0001)
   expect_equal(attr(nmrfiltered, "filters")[[1]]$filtered,
-               c("F3-098", "F4-009", "F4-005"))
+               c("F3-098", "F4-009", "F4-005", "F4-037"))
   expect_true(is.na(attr(nmrfiltered, "filters")[[1]]$method))
 
   # Investigate the data_info attribute.
@@ -428,21 +426,20 @@ test_that("rmd_filter and applyFilt produce the correct output",{
 
   # Dissect the group_DF attribute.
   expect_equal(dim(attr(nmrfiltered, "group_DF")),
-               c(38, 2))
+               c(37, 2))
   expect_equal(attr(nmrfiltered, "group_DF")$SampleID,
-               c("F3-049", "F3-097", "F3-002", "F3-050", "F3-013", "F3-061",
-                 "F3-109", "F3-062", "F3-110", "F3-025", "F3-073", "F3-121",
-                 "F3-026", "F3-074", "F3-122", "F3-085", "F3-133", "F3-038",
-                 "F3-086", "F3-134", "F4-001", "F4-065", "F4-069", "F4-037",
-                 "F4-017", "F4-045", "F4-021", "F4-049", "F4-081", "F4-025",
-                 "F4-053", "F4-085", "F4-029", "F4-057", "F4-089", "F4-033",
-                 "F4-061", "F4-093"))
+               c("F3-049", "F3-097", "F3-002", "F3-050", "F3-013", "F3-061", 
+                 "F3-109", "F3-062", "F3-110", "F3-025", "F3-073", "F3-121", "F3-026", 
+                 "F3-074", "F3-122", "F3-085", "F3-133", "F3-038", "F3-086", "F3-134", 
+                 "F4-001", "F4-065", "F4-069", "F4-017", "F4-045", "F4-021", "F4-049", 
+                 "F4-081", "F4-025", "F4-053", "F4-085", "F4-029", "F4-057", "F4-089", 
+                 "F4-033", "F4-061", "F4-093"))
 
   # Inspect the filtered e_data, f_data, and e_meta data frames.
   expect_equal(dim(nmrfiltered$e_data),
-               c(38, 39))
+               c(38, 38))
   expect_equal(dim(nmrfiltered$f_data),
-               c(38, 5))
+               c(37, 5))
   expect_equal(dim(nmrfiltered$e_meta),
                c(38, 3))
 
@@ -466,7 +463,8 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_identical(attr(pfiltered_sg, "filters")[[1]]$threshold,
                    0.0000000000000008)
   expect_equal(attr(pfiltered_sg, "filters")[[1]]$filtered,
-               c("Infection7", "Infection9"))
+               c("Infection1", "Infection3", "Infection4", "Infection7", 
+                 "Infection9"))
   expect_true(is.na(attr(pfiltered_sg, "filters")[[1]]$method))
 
   # Investigate the data_info attribute.
@@ -493,16 +491,16 @@ test_that("rmd_filter and applyFilt produce the correct output",{
 
   # Dissect the group_DF attribute.
   expect_equal(dim(attr(pfiltered_sg, "group_DF")),
-               c(8, 2))
+               c(5, 2))
   expect_equal(attr(pfiltered_sg, "group_DF")$SampleID,
-               c("Infection1", "Infection2", "Infection3", "Infection4",
-                 "Infection5", "Infection6", "Infection8", "Mock1"))
+               c("Infection2", "Infection5", "Infection6", "Infection8", "Mock1"
+               ))
 
   # Inspect the filtered e_data, f_data, and e_meta data frames.
   expect_equal(dim(pfiltered_sg$e_data),
-               c(150, 9))
+               c(150, 6))
   expect_equal(dim(pfiltered_sg$f_data),
-               c(8, 2))
+               c(5, 2))
   expect_equal(dim(pfiltered_sg$e_meta),
                c(150, 4))
 
@@ -683,15 +681,15 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_equal(pair_filter$Name, fdata$Name)
   expect_equal(pair_filter$Group, rep("paired_diff", 30))
   expect_equal(round(pair_filter$Log2.md, 3),
-               c(1.201, 0.455, 4.439, 2.086, 1.153, 0.794, 1.472, 0.316, 2.123,
-                 1.651, 2.345, 3.44, 2.028, 1.374, 3.235, 2.474, 2.488, 2.533,
-                 2.363, 2.58, 1.186, 1.056, 1.451, 1.504, -0.005, 2.21, 4.319,
-                 1.654, 2.1, 2.47))
+               c(1.42, 0.675, 4.659, 2.305, 1.372, 1.014, 1.692, 0.536, 2.343, 
+                 1.871, 2.564, 3.66, 2.248, 1.594, 3.455, 2.694, 2.707, 2.753, 
+                 2.583, 2.8, 1.405, 1.276, 1.671, 1.724, 0.215, 2.43, 4.539, 1.874, 
+                 2.32, 2.689))
   expect_equal(round(pair_filter$pvalue, 3),
-               c(0.807, 0.927, 0.001, 0.515, 0.817, 0.885, 0.735, 0.941, 0.499,
-                 0.678, 0.406, 0.054, 0.538, 0.763, 0.094, 0.352, 0.346, 0.327,
-                 0.399, 0.308, 0.81, 0.838, 0.741, 0.725, 0.963, 0.463, 0.001,
-                 0.677, 0.509, 0.354))
+               c(0.75, 0.902, 0, 0.423, 0.763, 0.847, 0.665, 0.919, 0.407, 0.6, 
+                 0.315, 0.027, 0.447, 0.697, 0.052, 0.263, 0.258, 0.241, 0.307, 
+                 0.223, 0.754, 0.788, 0.672, 0.653, 0.949, 0.37, 0, 0.599, 0.417, 
+                 0.265))
   expect_equal(round(pair_filter$MAD, 3),
                c(0.1, 0.087, 0.09, 0.076, 0.094, 0.076, 0.095, 0.091, 0.091,
                  0.081, 0.075, 0.077, 0.07, 0.075, 0.091, 0.097, 0.089, 0.089,
@@ -724,7 +722,7 @@ test_that("rmd_filter and applyFilt produce the correct output",{
   expect_identical(attr(pair_filtered, "filters")[[1]]$threshold,
                    0.001)
   expect_equal(attr(pair_filtered, "filters")[[1]]$filtered,
-               c("Mock_0hr_3", "Mock_18hr_3"))
+               c("Mock_0hr_3", "Mock_18hr_3", "AM_0hr_2", "AM_18hr_2"))
   expect_true(is.na(attr(pair_filtered, "filters")[[1]]$method))
   expect_equal(
     attr(pair_filtered, "data_info"),
@@ -745,15 +743,15 @@ test_that("rmd_filter and applyFilt produce the correct output",{
          num_emeta = length(unique(pair_filtered$e_meta$Protein)))
   )
   expect_equal(dim(attr(pair_filtered, "group_DF")),
-               c(28, 2))
+               c(26, 2))
   expect_equal(attr(attr(pair_filtered, "group_DF"), "main_effects"),
                "no_main_effect")
   expect_equal(attr(attr(pair_filtered, "group_DF"), "nonsingleton_groups"),
                "paired_diff")
   expect_equal(dim(pair_filtered$e_data),
-               c(150, 29))
+               c(150, 27))
   expect_equal(dim(pair_filtered$f_data),
-               c(28, 6))
+               c(26, 6))
   expect_equal(dim(pair_filtered$e_meta),
                c(175, 6))
 


### PR DESCRIPTION
Addressing the big scary "x" on master right now.  Basically, between the last successful CI run and now, robustbase was updated here:  https://github.com/cran/robustbase/commit/335b69f2310bd21ca4cdfc17a2a99ebbcad84017

This causes changes in the robust pca results from rrcov::PcaHubert, which causes a bunch of tests related to the rMd filter to fail.  Specifically, the rMd values and subsequently the p-values are different, however they are still highly correlated (.98+) to the previous values.  