### PR TITLE
Fix for null projection matrix

### DIFF
--- a/inst/testdata/imd_anova_standard_fns.R
+++ b/inst/testdata/imd_anova_standard_fns.R
@@ -7,10 +7,10 @@ proj_mat <- function(X, ngroups){
   if(!is.null(nrow(X))){
     Imat <- diag(1,nrow(X))
     
-    # Zero out the first ngroups rows of X because we only want to remove the
-    # effect of the covariates (which appear in the last n_covariates rows of
+    # Zero out the first ngroups cols of X because we only want to remove the
+    # effect of the covariates (which appear in the last n_covariates cols of
     # X).
-    X[1:ngroups, ] <- 0
+    X[, 1:ngroups] <- 0
     
     Px <- MASS::ginv(t(X)%*%X)%*%t(X)
     

--- a/inst/testdata/imd_anova_standard_fns.R
+++ b/inst/testdata/imd_anova_standard_fns.R
@@ -6,11 +6,14 @@ proj_mat <- function(X, ngroups){
   #into the null space corresponding to X
   if(!is.null(nrow(X))){
     Imat <- diag(1,nrow(X))
-    Px <- MASS::ginv(t(X)%*%X)%*%t(X)
-    # Zero out the first ngroups rows of Px because we only want to remove the
+    
+    # Zero out the first ngroups rows of X because we only want to remove the
     # effect of the covariates (which appear in the last n_covariates rows of
-    # Px).
-    Px[1:ngroups, ] <- 0
+    # X).
+    X[1:ngroups, ] <- 0
+    
+    Px <- MASS::ginv(t(X)%*%X)%*%t(X)
+    
     Px <- X%*%Px
     return(Imat-Px)
   }

--- a/src/imd_anova.cpp
+++ b/src/imd_anova.cpp
@@ -631,12 +631,12 @@ List proj_mat_cpp(arma::mat X, int ngroups){
   arma::uword PxRank;
   Imat.eye();
   
-  // 8/14/23 correction: Set the first ngroups rows of the design matrix
+  // 8/14/23 correction: Set the first ngroups cols of the design matrix
   // to be 0 so that projection is into the null space of the covariates-
   // only version of X. This is equivalent to fitting a regression based on
   // the covariates alone, and then obtaining the residuals (i.e. the residuals
   // are the null projection)
-  X.head_rows(ngroups).zeros();
+  X.head_cols(ngroups).zeros();
 
   // Moore-Penrose pseudo-inverse, can always (?) be found but takes longer
   Px = pinv(X.t()*X)*X.t();

--- a/src/imd_anova.cpp
+++ b/src/imd_anova.cpp
@@ -630,14 +630,23 @@ List proj_mat_cpp(arma::mat X, int ngroups){
   arma::mat Imat(n,n);
   arma::uword PxRank;
   Imat.eye();
+  
+  // 8/14/23 correction: Set the first ngroups rows of the design matrix
+  // to be 0 so that projection is into the null space of the covariates-
+  // only version of X. This is equivalent to fitting a regression based on
+  // the covariates alone, and then obtaining the residuals (i.e. the residuals
+  // are the null projection)
+  X.head_rows(ngroups).zeros();
 
   // Moore-Penrose pseudo-inverse, can always (?) be found but takes longer
   Px = pinv(X.t()*X)*X.t();
 
-  // Set first ngroups rows to be zero
-  Px.head_rows(ngroups).zeros();
+  // Px (below) is the projection matrix that projects onto the columnspace of X
   Px = X*Px;
   PxRank = rank(Px);
+  
+  // Imax - Px is the projection matrix that projects onto the nullspace of X
+  
   return List::create(Named("Ipx") = Imat-Px,
                       Named("PxRank") = PxRank);
 }


### PR DESCRIPTION
This branch contains changes to the cpp functions (and one function in inst used for tests) relating to the computation of the null projection matrix. 

The fixes introduced by this code have been verified against base R output in terms of the output data values. Specifically, this fix ensures that the null-projected data correspond to the residuals obtained when regressing your response on covariates. 

Assessing this fix further by comparing resulting p-values, however, I find that the pmartR p-values are close, but not quite the same as base R p-values. The difference is large enough that I would be skeptical if entirely attributable to rounding errors and so I recommend further investigation.  