### PR TITLE
add threshold argument to edata_replace

### DIFF
--- a/R/edata_replace.R
+++ b/R/edata_replace.R
@@ -76,6 +76,13 @@ edata_replace <- function(omicsData, x, y, threshold = NULL) {
   # also count the number of values below the threshold and get indices to 
   # replace
   if (!is.null(threshold)) {
+    max_val <- max(omicsData$e_data[, -id_col], na.rm = TRUE)
+    min_val <- min(omicsData$e_data[, -id_col], na.rm = TRUE)
+
+    if (threshold < min_val || threshold > max_val) {
+      stop("The threshold value is outside the range of the data.  Check your that your data is on the scale you expect, and that the threshold value is within the range of the data.")
+    }
+
     cond_thresh <- omicsData$e_data[, -id_col] < threshold
     cond_match <- if(is.na(x)) {
       !is.na(omicsData$e_data[, -id_col])

--- a/man/edata_replace.Rd
+++ b/man/edata_replace.Rd
@@ -4,7 +4,7 @@
 \alias{edata_replace}
 \title{Replace Values Equal to x with y}
 \usage{
-edata_replace(omicsData, x, y)
+edata_replace(omicsData, x, y, threshold = NULL)
 }
 \arguments{
 \item{omicsData}{an object of the class 'pepData', 'proData', 'metabData',
@@ -15,6 +15,9 @@ edata_replace(omicsData, x, y)
 \item{x}{value to be replaced, usually numeric or NA}
 
 \item{y}{replacement value, usually numeric or NA}
+
+\item{threshold}{Positive numeric value.  Observed values below this
+threshold will be replaced by `y` (in addition to all `x` values).}
 }
 \value{
 data object of the same class as omicsData

--- a/tests/testthat/test_edata_replace.R
+++ b/tests/testthat/test_edata_replace.R
@@ -96,6 +96,22 @@ test_that('edata_replace correctly replaces one value with another', {
     c('isobaricpepData', 'pepData')
   )
 
+  # Use a threshold
+  thresh = quantile(isodata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(isodata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    isodata2 <- edata_replace(
+      omicsData = isodata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(isodata2$e_data == 0), 400 + num_thresholded)
+
   # Load: lipidData ------------------------------------------------------------
 
   load(system.file('testdata',
@@ -172,6 +188,22 @@ test_that('edata_replace correctly replaces one value with another', {
     'lipidData'
   )
 
+  # Use a threshold
+  thresh = quantile(ldata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(ldata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    ldata2 <- edata_replace(
+      omicsData = ldata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(ldata2$e_data == 0), 884 + num_thresholded)
+
   # Load: metabData ------------------------------------------------------------
 
   load(system.file('testdata',
@@ -247,6 +279,22 @@ test_that('edata_replace correctly replaces one value with another', {
     mdata2,
     'metabData'
   )
+
+  # Use a threshold
+  thresh = quantile(mdata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(mdata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    mdata2 <- edata_replace(
+      omicsData = mdata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(mdata2$e_data == 0), 148 + num_thresholded)
 
   # Load: nmrData --------------------------------------------------------------
 
@@ -344,6 +392,22 @@ test_that('edata_replace correctly replaces one value with another', {
     'nmrData'
   )
 
+  # Use a threshold
+  thresh = quantile(nmrdata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(nmrdata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    nmrdata2 <- edata_replace(
+      omicsData = nmrdata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(nmrdata2$e_data == 0), 302 + num_thresholded)
+
   # Load: pepData --------------------------------------------------------------
 
   load(system.file('testdata',
@@ -420,6 +484,22 @@ test_that('edata_replace correctly replaces one value with another', {
     'pepData'
   )
 
+  # Use a threshold
+  thresh = quantile(pdata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(pdata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    pdata2 <- edata_replace(
+      omicsData = pdata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(pdata2$e_data == 0), 341 + num_thresholded)
+
   # Load: proData --------------------------------------------------------------
 
   load(system.file('testdata',
@@ -495,6 +575,22 @@ test_that('edata_replace correctly replaces one value with another', {
     prdata,
     'proData'
   )
+
+  # Use a threshold
+  thresh = quantile(prdata$e_data[,-1], na.rm=TRUE)[2]
+  num_thresholded <- sum(prdata$e_data[,-1] < thresh, na.rm = TRUE)
+
+  expect_message(
+    prdata2 <- edata_replace(
+      omicsData = prdata,
+      x = NA,
+      y = 0,
+      threshold = thresh
+    ),
+    sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_equal(sum(prdata2$e_data == 0), 234 + num_thresholded)
 
   # Test: seqData ------------------------------------------------------
   load(system.file('testdata',

--- a/tests/testthat/test_edata_replace.R
+++ b/tests/testthat/test_edata_replace.R
@@ -110,6 +110,16 @@ test_that('edata_replace correctly replaces one value with another', {
     sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
   )
 
+  expect_error(
+    edata_replace(
+      omicsData = isodata,
+      x = NA,
+      y = 0,
+      threshold = min(isodata$e_data[,-1], na.rm=TRUE) - 1
+    ),
+    'outside the range of the data'
+  )
+
   expect_equal(sum(isodata2$e_data == 0), 400 + num_thresholded)
 
   # Load: lipidData ------------------------------------------------------------
@@ -200,6 +210,16 @@ test_that('edata_replace correctly replaces one value with another', {
       threshold = thresh
     ),
     sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_error(
+    edata_replace(
+      omicsData = ldata,
+      x = NA,
+      y = 0,
+      threshold = max(ldata$e_data[,-1], na.rm=TRUE) + 1
+    ),
+    'outside the range of the data'
   )
 
   expect_equal(sum(ldata2$e_data == 0), 884 + num_thresholded)
@@ -406,6 +426,16 @@ test_that('edata_replace correctly replaces one value with another', {
     sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
   )
 
+  expect_error(
+    edata_replace(
+      omicsData = nmrdata,
+      x = NA,
+      y = 0,
+      threshold = max(nmrdata$e_data[,-1], na.rm=TRUE) + 1
+    ),
+    'outside the range of the data'
+  )
+
   expect_equal(sum(nmrdata2$e_data == 0), 302 + num_thresholded)
 
   # Load: pepData --------------------------------------------------------------
@@ -496,6 +526,16 @@ test_that('edata_replace correctly replaces one value with another', {
       threshold = thresh
     ),
     sprintf("%s values below the threshold %s have been replaced with %s", num_thresholded, thresh, 0)
+  )
+
+  expect_error(
+    edata_replace(
+      omicsData = pdata,
+      x = NA,
+      y = 0,
+      threshold = min(pdata$e_data[,-1], na.rm=TRUE) - 1
+    ),
+    'outside the range of the data'
   )
 
   expect_equal(sum(pdata2$e_data == 0), 341 + num_thresholded)


### PR DESCRIPTION
Argument in edata_replace `threshold`, which replaces any values below the threshold with the specified replacement value (`y`).  A message is displayed informing the user how many values were replaced.

closes #206