### PR TITLE
protein_quant: combine different emeta_cols values mapping to a protein

### DIFF
--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -282,16 +282,16 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
       # Use either the original or isoform e_meta depending on the input.
         pepData$e_meta <- pepData$e_meta %>%
           dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-          dplyr::summarise_all(.funs = \(x) paste(unique(x), collapse = ";"))
+          dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
       } else {
         results$e_meta <- results$e_meta %>%
           dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-          dplyr::summarise_all(.funs = \(x) paste(unique(x), collapse = ";"))
+          dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
       }
     } else {
       e_meta <- e_meta %>%
         dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-        dplyr::summarise_all(.funs = \(x) paste(unique(x), collapse = ";"))
+        dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
     }
   }
 

--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -138,8 +138,6 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
   # Grab more attributes that will be used at some point somewhere.
   data_scale <- get_data_scale(pepData)
   is_normalized <- attr(pepData, "data_info")$norm_info$is_normalized
-
-  browser()
   
   # Prepare attribute info when isoformRes is present.
   if (!is.null(isoformRes)) {

--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -291,12 +291,23 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
                    nrow()
           )
       } else {
-        if (nrow(e_meta_iso) != n_row_edata) {
-          warning("One or more columns in emeta_cols contained values which ",
-                  "were not correctly aligned to the proteins. No emeta_cols ",
-                  "columns will be used.")
-          emeta_cols <- NULL
-        }
+        n_row_emeta <- 
+          sapply(emeta_cols, \(x)
+            e_meta %>%
+            dplyr::select(
+              all_of(c(emeta_cname, emeta_cols))
+            ) %>% 
+            dplyr::left_join(
+              e_meta_iso,
+              by = emeta_cname,
+              multiple = "all",
+              relationship = "many-to-many") %>%
+            dplyr::select(
+              !!dplyr::sym(emeta_cname_iso), !!dplyr::sym(x)
+            ) %>%
+            dplyr::distinct() %>%
+            nrow()
+          )
       }
     } else {
       n_row_emeta <- 

--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -23,6 +23,9 @@
 #'   that should be kept after rolling up to the protein level. The default,
 #'   NULL, only keeps the column containing the mapping variable along with the
 #'   new columns created (peps_per_pro and n_peps_used).
+#' @param emeta_cols_sep character specifying the string that will separate the 
+#'   elements for emeta_cols when they are collapsed into a single row when aggregating
+#'   rows belonging to the same protein.  Defaults to ";"
 #'
 #' @return omicsData object of the class 'proData'
 #'
@@ -71,7 +74,7 @@
 protein_quant <- function(pepData, method, isoformRes = NULL,
                           qrollup_thresh = NULL, single_pep = FALSE,
                           single_observation = FALSE, combine_fn = "median",
-                          parallel = TRUE, emeta_cols = NULL) {
+                          parallel = TRUE, emeta_cols = NULL, emeta_cols_sep = ";") {
   # Preflight checks -----------------------------------------------------------
 
   # Make sure the data are on one of the log scales.
@@ -282,16 +285,16 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
       # Use either the original or isoform e_meta depending on the input.
         pepData$e_meta <- pepData$e_meta %>%
           dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-          dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
+          dplyr::mutate(dplyr::across(emeta_cols, \(x) paste(unique(x), collapse = emeta_cols_sep)))
       } else {
         results$e_meta <- results$e_meta %>%
           dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-          dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
+          dplyr::mutate(dplyr::across(emeta_cols, \(x) paste(unique(x), collapse = emeta_cols_sep)))
       }
     } else {
       e_meta <- e_meta %>%
         dplyr::group_by(!!dplyr::sym(emeta_cname)) %>%
-        dplyr::summarise_at(emeta_cols, .funs = \(x) paste(unique(x), collapse = ";"))
+        dplyr::mutate(dplyr::across(emeta_cols, \(x) paste(unique(x), collapse = emeta_cols_sep)))
     }
   }
 

--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -323,9 +323,10 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
     
     # Remove the invalid columns
     if (length(invalid_emeta_cols) > 0) {
-      warning("One or more columns in emeta_cols contained values which ",
-              "were not correctly aligned to the proteins. These columns ",
-              "will be removed: ", 
+      warning("One or more columns from the peptide level e_meta contained ",
+              "values which, when rolling up to protein level e_meta, could ",
+              "not be retained because more than one value per protein ",
+              "resulted. These columns will be removed: ", 
               emeta_cols[invalid_emeta_cols])
       emeta_cols <- emeta_cols[-invalid_emeta_cols]
     }

--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -379,12 +379,12 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
     } else {
       # Count peptides per isoform from the bpquant output.
       isoformRes2 %>%
-        dplyr::group_by(Protein_Isoform) %>%
+        dplyr::group_by(!!dplyr::sym(emeta_cname_iso)) %>%
         dplyr::mutate(n_peps_used = dplyr::n()) %>%
         # Only keep the first row of each group.
         dplyr::slice(1) %>%
         dplyr::ungroup() %>%
-        dplyr::select(!!dplyr::sym(emeta_cname), n_peps_used)
+        dplyr::select(!!dplyr::sym(emeta_cname_iso), n_peps_used)
     }
 
     # store total number of peptides mapping to each protein (different from
@@ -413,7 +413,9 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
         relationship = "many-to-many"
       ) %>%
       dplyr::left_join(peps_used,
-                       by = emeta_cname,
+                       by = ifelse(is.null(isoformRes),
+                                   emeta_cname,
+                                   emeta_cname_iso),
                        multiple = "all",
                        relationship = "many-to-many") %>%
       # Move any columns specified by the user after n_peps_used.

--- a/man/protein_quant.Rd
+++ b/man/protein_quant.Rd
@@ -13,7 +13,8 @@ protein_quant(
   single_observation = FALSE,
   combine_fn = "median",
   parallel = TRUE,
-  emeta_cols = NULL
+  emeta_cols = NULL,
+  emeta_cols_sep = ";"
 )
 }
 \arguments{
@@ -44,6 +45,10 @@ rrollup, qrollup and zrollup functions.}
 that should be kept after rolling up to the protein level. The default,
 NULL, only keeps the column containing the mapping variable along with the
 new columns created (peps_per_pro and n_peps_used).}
+
+\item{emeta_cols_sep}{character specifying the string that will separate the 
+elements for emeta_cols when they are collapsed into a single row when aggregating
+rows belonging to the same protein.  Defaults to ";"}
 }
 \value{
 omicsData object of the class 'proData'

--- a/tests/testthat/test_quant_protein.R
+++ b/tests/testthat/test_quant_protein.R
@@ -130,7 +130,8 @@ test_that('each rollup method correctly quantifies proteins', {
       dplyr::group_by(Protein) %>%
       dplyr::mutate(peps_per_pro = dplyr::n()) %>%
       dplyr::mutate(n_peps_used = peps_per_pro) %>%
-      dplyr::select(Protein, peps_per_pro, n_peps_used) %>%
+      dplyr::mutate(dplyr::across('Peptide_Sequence', \(x) paste(unique(x), collapse = ";"))) %>%
+      dplyr::select(Protein, peps_per_pro, n_peps_used, Peptide_Sequence) %>%
       dplyr::distinct(.) %>%
       data.frame(),
     edata_cname = "Protein",
@@ -559,9 +560,10 @@ test_that('each rollup method correctly quantifies proteins', {
       dplyr::mutate(n_peps_used = dplyr::n()) %>%
       dplyr::left_join(pepes_per_pro2, by = "Protein", multiple = "all", relationship = "many-to-many") %>%
       dplyr::relocate(n_peps_used, .after = peps_per_pro) %>%
+      dplyr::mutate(dplyr::across('Peptide_Sequence', \(x) paste(unique(x), collapse = ";"))) %>%
       dplyr::distinct(
         Protein, Protein_Isoform, peps_per_pro,
-        n_peps_used
+        n_peps_used, Peptide_Sequence
       ) %>%
       data.frame(),
     edata_cname = "Protein_Isoform",


### PR DESCRIPTION
Putting this here to be a bit more visible, but there are still a couple things that need to be addressed:

- ~~Wording of the warning~~
- ~~What to do with isoform e_meta version~~
- Ensure tests pass

Example test cases:

```r
# This code should succeed without any warnings, with column B remaining in e_meta
mypepData <- group_designation(omicsData = pep_object, main_effects = c("Phenotype"))
mypepData = edata_transform(omicsData = mypepData, "log2")

imdanova_Filt <- imdanova_filter(omicsData = mypepData)
mypepData <- applyFilt(filter_object = imdanova_Filt, omicsData = mypepData, min_nonmiss_anova = 2)

imd_anova_res <- imd_anova(omicsData = mypepData, test_method = 'comb', pval_adjust_a_multcomp = 'bon', pval_adjust_g_multcomp = 'bon')

mypepData$e_meta$B <- sapply(mypepData$e_meta$RazorProtein, nchar)

results <- protein_quant(pepData = mypepData, method = 'rollup', combine_fn = 'median', emeta_cols = "B")
print(names(results$e_meta))
```

```r
# This code should give a warning and remove the A column from e_meta
mypepData <- group_designation(omicsData = pep_object, main_effects = c("Phenotype"))
mypepData = edata_transform(omicsData = mypepData, "log2")

imdanova_Filt <- imdanova_filter(omicsData = mypepData)
mypepData <- applyFilt(filter_object = imdanova_Filt, omicsData = mypepData, min_nonmiss_anova = 2)

imd_anova_res <- imd_anova(omicsData = mypepData, test_method = 'comb', pval_adjust_a_multcomp = 'bon', pval_adjust_g_multcomp = 'bon')

mypepData$e_meta$A <- round(runif(nrow(mypepData$e_meta)), 1)*10

results <- protein_quant(pepData = mypepData, method = 'rollup', combine_fn = 'median', emeta_cols = "A")
print(names(results$e_meta))
```

```r
# This code should give a warning about and remove column A, but still keep the B column in the e_meta
mypepData <- group_designation(omicsData = pep_object, main_effects = c("Phenotype"))
mypepData = edata_transform(omicsData = mypepData, "log2")

imdanova_Filt <- imdanova_filter(omicsData = mypepData)
mypepData <- applyFilt(filter_object = imdanova_Filt, omicsData = mypepData, min_nonmiss_anova = 2)

imd_anova_res <- imd_anova(omicsData = mypepData, test_method = 'comb', pval_adjust_a_multcomp = 'bon', pval_adjust_g_multcomp = 'bon')

mypepData$e_meta$A<- round(runif(nrow(mypepData$e_meta)), 1)*10
mypepData$e_meta$B<- sapply(mypepData$e_meta$RazorProtein, nchar)

results <- protein_quant(pepData = mypepData, method = 'rollup', combine_fn = 'median', emeta_cols = c("A", "B"))
print(names(results$e_meta))
```

```r
# This code should also give a warning about column A and keep column B, but should use isoforms.
mypepData <- group_designation(omicsData = pep_object, main_effects = c("Phenotype"))
mypepData = edata_transform(omicsData = mypepData, "log2")

imdanova_Filt <- imdanova_filter(omicsData = mypepData)
mypepData <- applyFilt(filter_object = imdanova_Filt, omicsData = mypepData, min_nonmiss_anova = 2)

imd_anova_res <- imd_anova(omicsData = mypepData, test_method = 'comb', pval_adjust_a_multcomp = 'bon', pval_adjust_g_multcomp = 'bon')

isoformRes = bpquant(statRes = imd_anova_res, pepData = mypepData)

mypepData$e_meta$A<- round(runif(nrow(mypepData$e_meta)), 1)*10
mypepData$e_meta$B<- sapply(mypepData$e_meta$RazorProtein, nchar)

protein_quant(pepData = mypepData, method = 'rollup', combine_fn = 'median', isoformRes = isoformRes, emeta_cols = c("A", "B"))
```