### PR TITLE
protein_quant error on biomolecules with no observations

### DIFF
--- a/R/protein_quant.R
+++ b/R/protein_quant.R
@@ -121,6 +121,12 @@ protein_quant <- function(pepData, method, isoformRes = NULL,
     stop("emeta_cols must be a character vector.")
   }
 
+  # check that there are no biomolecules with zero observations
+  num_present_by_row <- rowSums(!is.na(pepData$e_data[, -which(names(pepData$e_data) == get_edata_cname(pepData))]))
+  if (min(num_present_by_row) == 0) {
+    stop("Your data contains biomolecules not observed in any of the samples:  please apply a molecule filter to remove these biomolecules before running protein_quant.")
+  }
+  
   # Set the combine_fn input to the appropriate function.
   if (combine_fn == "median") {
     chosen_combine_fn <- combine_fn_median

--- a/tests/testthat/test_quant_protein.R
+++ b/tests/testthat/test_quant_protein.R
@@ -671,4 +671,12 @@ test_that('each rollup method correctly quantifies proteins', {
 
   # Compare the output to the standards.
   expect_identical(stan_qr_med_bayes, qr_med_bayes)
+  
+  # Check that error is thrown in any biomolecules have zero observations
+  pdata_zero <- pdata
+  pdata_zero$e_data[sample(1:nrow(pdata_zero$e_data)), -which(colnames(pdata_zero$e_data) == get_edata_cname(pdata_zero))] <- NA
+  expect_error(
+    protein_quant(pdata_zero, method = "rrollup", combine_fn = "median"),
+    regexp = "Your data contains biomolecules not observed in any of the samples"
+  )
 })


### PR DESCRIPTION
The following should now throw an error:

```
library(pmartRdata)
library(pmartR)

obj <- pep_object
obj$e_data[1, -which(colnames(obj$e_data) == get_edata_cname(obj))] <- NA
protein_quant(obj, method = "rrollup", combine_fn = "median")

>> Error in protein_quant(obj, method = "rrollup", combine_fn = "median") : Your data contains biomolecules not observed in any of the samples:  please apply a molecule filter to remove these biomolecules before running protein_quant.
```