### PR TITLE
fix hard-coded column in cv_filter

### DIFF
--- a/R/filter_objects.R
+++ b/R/filter_objects.R
@@ -564,7 +564,7 @@ cv_filter <- function(omicsData, use_groups = TRUE) {
 
     # Make sure the order of the groups in group_DF matches the order of the
     # sample names in cur_edata.
-    groupie <- groupDF$Group[match(names(cur_edata), groupDF$SampleID)]
+    groupie <- groupDF$Group[match(names(cur_edata), groupDF[[get_fdata_cname(omicsData)]])]
 
     # Calculate the pooled CV. The data needs to be converted to a matrix and
     # the group names need to be converted to a character vector for


### PR DESCRIPTION
SampleID was hard-coded into a column selector for the group DF.  Result:  the 'group' for datasets without a column named 'SampleID' was `c(NA, NA, NA, ...)`, which is still a valid input to the pooled_cv calculator, but just gets assigned a single group (NA).

Tests still passed, since the test data had column `SampleID`.