### PR TITLE
Bugfix/arm64 fp

### DIFF
--- a/src/imd_anova.cpp
+++ b/src/imd_anova.cpp
@@ -696,6 +696,10 @@ NumericVector holm_cpp(NumericVector ps) {
 
   NumericVector sorted_ps = clone(ps);
   NumericVector adj_ps(n);
+  
+  if (n == 0) {
+    return adj_ps;
+  }
 
   // Sort p-values in ascending order with NA/NaN at the end of the vector.
   std::sort(sorted_ps.begin(), sorted_ps.end(), withNaN);

--- a/src/kw_rcpp.cpp
+++ b/src/kw_rcpp.cpp
@@ -70,7 +70,12 @@ double calculate_kwh(std::vector <std::vector <double> > ranks, std::vector <dou
     summation = summation + rsums[i];
   }
   
-  result = ((12/(n*(n+1)))*summation)- 3*(n+1);
+  result = ((12.0/(n*(n+1)))*summation) - 3.0*(n+1);
+  
+  /* handle strange floating point errors */
+  if (result < 0) {
+    result = 0.0;
+  }
   
   return result;
 }


### PR DESCRIPTION
Two fixes:

#287 where I round up to zero for arm64.  Why it happens on arm64 only is beyond me, but I believe the solution is valid.

Failures on R-devel related to indexing a zero-size array in holm_cpp