### PR TITLE
Update applyFilt.R

### DIFF
--- a/R/applyFilt.R
+++ b/R/applyFilt.R
@@ -1992,11 +1992,9 @@ pmartR_filter_worker <- function(filter_object, omicsData) {
     # e_data
     valid_edata <- omicsData$e_data[, get_edata_cname(omicsData)]
 
-    missing_biomolecules <- unlist(
-      lapply(filter_object$e_data_remove, function(x) if (!(x %in% valid_edata)) x)
-    )
+    missing_biomolecules <- filter_object$e_data_remove[!(filter_object$e_data_remove %in% valid_edata)]
 
-    if (length(missing_biomolecules > 0)) {
+    if (length(missing_biomolecules) > 0) {
       warning(
         "Specified biomolecules ",
         paste0(missing_biomolecules, collapse = ", "),
@@ -2007,11 +2005,9 @@ pmartR_filter_worker <- function(filter_object, omicsData) {
     # f_data
     valid_fdata <- valid_names <- omicsData$f_data[, get_fdata_cname(omicsData)]
 
-    missing_samples <- unlist(
-      lapply(filter_object$f_data_remove, function(x) if (!(x %in% valid_fdata)) x)
-    )
+    missing_samples <- filter_object$f_data_remove[!(filter_object$f_data_remove %in% valid_fdata)]
 
-    if (length(missing_samples > 0)) {
+    if (length(missing_samples) > 0) {
       warning(
         "Specified samples ",
         paste0(missing_samples, collapse = ", "),
@@ -2023,11 +2019,9 @@ pmartR_filter_worker <- function(filter_object, omicsData) {
     # e_meta
     valid_emeta <- omicsData$e_meta[, get_emeta_cname(omicsData)]
 
-    missing_emeta <- unlist(
-      lapply(filter_object$e_meta_remove, function(x) if (!(x %in% valid_emeta)) x)
-    )
+    missing_emeta <- filter_object$e_meta_remove[!(filter_object$e_meta_remove %in% valid_emeta)]
 
-    if (length(missing_emeta > 0)) {
+    if (length(missing_emeta) > 0) {
       warning(
         "Specified e_meta values ",
         paste0(missing_emeta, collapse = ", "),


### PR DESCRIPTION
Some code in pmartR_filter_worker written inefficiently, requiring much time to complete for big data.

Replace all styled like this:

    `missing_biomolecules <- unlist(
      lapply(filter_object$e_data_remove, function(x) if (!(x %in% valid_edata)) x)
    )`
    
To this:
    
    `missing_biomolecules <- filter_object$e_data_remove[!(filter_object$e_data_remove %in% valid_edata)]`
  
The changed variables are only used in warnings, not any filter calculations.

Example performance improvement with isobaric data (from pmartRdata), where filter_object$e_data_remove is length 59073:

<img width="954" alt="image" src="https://github.com/user-attachments/assets/461eaf29-1411-4801-9a79-f48ebbaeeb83">

____


If you wanna see for yourself, try this from this branch vs master:

```{r}
auto_remove_na <- function(omicsData){
  id_col <- which(colnames(omicsData$e_data) == get_edata_cname(omicsData))
  remove_edata <- omicsData$e_data[[id_col]][
    apply(is.na(omicsData$e_data[-id_col]), 1, all)]
  if(length(remove_edata) > 0){
    filt <- custom_filter(omicsData, e_data_remove = remove_edata)
    return(applyFilt(filt, omicsData))
  } else return(omicsData)
}

tictoc::tic()

summary(auto_remove_na(pmartRdata::isobaric_object))

tictoc::toc()

```

