### PR TITLE
Fix bad key reference in development version of Bioconductor/edgeR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pmartR
 Type: Package
 Title: Panomics Marketplace - Quality Control and Statistical Analysis for Panomics Data
-Version: 2.4.5
-Date: 2024-5-16
+Version: 2.4.6
+Date: 2024-10-8
 Authors@R: c(
     person("Lisa", "Bramer", email = "lisa.bramer@pnnl.gov", role = c("aut", "cre")), 
     person("Kelly", "Stratton", email = "kelly.stratton@pnnl.gov", role = c("aut")), 

--- a/R/seqData_wrappers.R
+++ b/R/seqData_wrappers.R
@@ -1334,12 +1334,19 @@ dispersion_est <- function(omicsData, method,
 
     fit_edgeR <- edgeR::glmQLFit(D_edgeR, design_matrix)
 
+    # edgeR people hate us
+    prior_name <- intersect(c("s2.prior", "var.prior"), names(fit_edgeR))
+    post_name <- intersect(c("s2.post", "var.post"), names(fit_edgeR))
+    
+    prior <- fit_edgeR[[prior_name]]
+    post <- fit_edgeR[[post_name]]
+    
     df2 <- data.frame(
       CD = D_edgeR$common.dispersion,
       TD = D_edgeR$trended.dispersion,
       TagD = D_edgeR$tagwise.dispersion,
-      fitD1 = fit_edgeR$var.prior,
-      fitD2 = fit_edgeR$var.post,
+      fitD1 = prior,
+      fitD2 = post,
       AveLogCPM = fit_edgeR$AveLogCPM
     )
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ install.packages("pmartR")
 BiocManager::install("pmartR")
 ```
 
-If you are on Mac/Windows and have a recent R version, you can skip compilation by installing from binaries, see the [pmartR CRAN page](https://cran.r-project.org/web/packages/pmartR/index.html) for available binaries.
+If you are on Mac/Windows and have a recent R version, you can skip compilation by installing from binaries, see the [pmartR CRAN page](https://CRAN.R-project.org/package=pmartR) for available binaries.
 
 ```r
 install.packages("pmartR", type = "binary")

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To get started, see the package documentation and function reference located [he
 Example peptide (both unlabeled and isobaric labeled), protein, metabolite and lipid data are available in the __pmartRdata__ package available on Github, [here](https://github.com/pmartR/pmartRdata)
 
 ## Contributing
-See the [contributing docs](.github/CONTRIBUTING.md).
+See the [contributing docs](https://github.com/pmartR/pmartR/blob/master/.github/CONTRIBUTING.md).
 
 ## Citation:
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,5 @@
-# (Resubmit) Version 2.4.5 May 17, 2024
+# Version 2.4.6 October 8, 2024
 
-Fixed a stale url in README that was causing a NOTE.  
+Fixing errors related to the devel version of Bioconductor/edgeR.
 
-Other NOTE's about pmartRdata hosted in a drat repo were previously okay.
-
-****
-
-Fixing errors in noSuggests checks.  Various minor bugfixes.
+Changed url in README to canonical form.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,8 @@
 # Version 2.4.6 October 8, 2024
 
+Made link to contributing docs full github url.
+
 Fixing errors related to the devel version of Bioconductor/edgeR.
 
 Changed url in README to canonical form.
+


### PR DESCRIPTION
They changed the name in flmQLFit objects from var.post/prior to s2.post/prior.  Made a change to make it compatible with either version.