### PR TITLE
Feature/imd anova model selection

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,7 +33,7 @@ anova_cpp <- function(data, gp, unequal_var, X, Beta, pred_grid, continuous_cova
     .Call('_pmartR_anova_cpp', PACKAGE = 'pmartR', data, gp, unequal_var, X, Beta, pred_grid, continuous_covar_inds, group_ids_pred)
 }
 
-two_factor_anova_cpp <- function(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection = 1L) {
+two_factor_anova_cpp <- function(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection = 2L) {
     .Call('_pmartR_two_factor_anova_cpp', PACKAGE = 'pmartR', data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,8 +33,8 @@ anova_cpp <- function(data, gp, unequal_var, X, Beta, pred_grid, continuous_cova
     .Call('_pmartR_anova_cpp', PACKAGE = 'pmartR', data, gp, unequal_var, X, Beta, pred_grid, continuous_covar_inds, group_ids_pred)
 }
 
-two_factor_anova_cpp <- function(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred) {
-    .Call('_pmartR_two_factor_anova_cpp', PACKAGE = 'pmartR', data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred)
+two_factor_anova_cpp <- function(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection = 1L) {
+    .Call('_pmartR_two_factor_anova_cpp', PACKAGE = 'pmartR', data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection)
 }
 
 group_comparison_anova_cpp <- function(means, data, sizes, which_xmatrix, Xfull, Xred, Cfull, Cred, Cmu) {

--- a/R/imd_anova.R
+++ b/R/imd_anova.R
@@ -32,11 +32,11 @@
 #'   biomolecules are considered differentially expressed. Defaults to 0.05
 #' @param equal_var logical; should the variance across groups be assumed equal?
 #' @param model_selection Character, one of 'full', 'reduced', or 'auto'
-#'  indicating the model to be used in the ANOVA analysis. The default 'full' uses all main
-#'  effects, covariates, and interactions between main effects. 'reduced' does 
-#'  not consider interactions between main effects. 'auto' performs an F-test
+#'  indicating the model to be used in the ANOVA analysis. The default 'auto' performs an F-test
 #'  to determine if the full model is necessary. If the F-test is significant,
-#'  the full model is used, otherwise the reduced model is used.
+#'  the full model is used, otherwise the reduced model is used.  'full' uses all main
+#'  effects, covariates, and interactions between main effects. 'reduced' does 
+#'  not consider interactions between main effects (only covariates and marginal main effects).
 #' @param parallel logical value indicating whether or not to use a
 #'   "doParallel" loop when running the G-Test with covariates. Defaults to
 #'   TRUE.
@@ -101,7 +101,7 @@ imd_anova <- function(omicsData,
                       pval_adjust_g_fdr = 'none',
                       pval_thresh = 0.05,
                       equal_var = TRUE,
-                      model_selection = "full",
+                      model_selection = "auto",
                       parallel = TRUE) {
   # Preliminaries --------------------------------------------------------------
 
@@ -259,7 +259,7 @@ imd_anova <- function(omicsData,
     stop("pval_thresh must be between 0 and 1.")
   }
 
-  if (!(model_selection %in% c("full", "reduced", "auto"))) {
+  if (!isTRUE(model_selection %in% c("full", "reduced", "auto"))) {
     stop("model_selection must be one of 'full', 'reduced', or 'auto'.")
   }
   

--- a/R/imd_anova.R
+++ b/R/imd_anova.R
@@ -259,6 +259,10 @@ imd_anova <- function(omicsData,
     stop("pval_thresh must be between 0 and 1.")
   }
 
+  if (!(model_selection %in% c("full", "reduced", "auto"))) {
+    stop("model_selection must be one of 'full', 'reduced', or 'auto'.")
+  }
+  
   # Statisticalness!!! ---------------------------------------------------------
 
   # Determine the non-missing per group counts for ALL biomolecules. Depending

--- a/inst/testdata/standards_imd_anova.R
+++ b/inst/testdata/standards_imd_anova.R
@@ -1242,7 +1242,8 @@ cobra <- run_twofactor_cpp(
   gpData = groupData[,c("Group", main_effect_names, covariate_names)], 
   Xfull=Xmatrix_2_1_4_full, Xred = Xmatrix_2_1_4,
   pred_grid_full = pred_grid_full_2_1_4, pred_grid_red = pred_grid_red_2_1_4,
-  continuous_covar_inds = numeric(0)
+  continuous_covar_inds = numeric(0),
+  model_selection = "auto"
 )
 
 group_counts_2_1_4 <- data.frame(check.names = FALSE, 
@@ -1653,7 +1654,8 @@ cobra <- run_twofactor_cpp(
   gpData = groupData[,c("Group", main_effect_names, covariate_names)], 
   Xfull=Xmatrix_2_2_4_full, Xred = Xmatrix_2_2_4,
   pred_grid_full = pred_grid_full_2_2_4, pred_grid_red = pred_grid_red_2_2_4,
-  continuous_covar_inds = 5
+  continuous_covar_inds = 5,
+  model_selection = "auto"
 )
 
 group_counts_2_2_4 <- data.frame(check.names = FALSE, 
@@ -2780,14 +2782,15 @@ dragon <- run_twofactor_cpp(
   Xred = Xmatrix_2_1_4,
   pred_grid_full = pred_grid_full_2_1_4,
   pred_grid_red = pred_grid_red_2_1_4,
-  continuous_covar_inds = numeric(0)
+  continuous_covar_inds = numeric(0),
+  model_selection = "auto"
 )
 
 mean_2_1_4 <- data.frame(check.names = FALSE, 
-  Mean_Infection_high = dragon$adj_group_means[, 1],
-  Mean_Infection_low = dragon$adj_group_means[, 2],
-  Mean_Mock_high = dragon$adj_group_means[, 3],
-  Mean_Mock_low = dragon$adj_group_means[, 4]
+  Mean_Infection_high = dragon$lsmeans[, 1],
+  Mean_Infection_low = dragon$lsmeans[, 2],
+  Mean_Mock_high = dragon$lsmeans[, 3],
+  Mean_Mock_low = dragon$lsmeans[, 4]
 )
 
 cmat = rbind(c(1, -1, 0, 0), c(1, 0, -1, 0), c(1, 0, 0, -1),
@@ -3021,14 +3024,15 @@ mustang <- run_twofactor_cpp(
   gpData = gdf,
   Xfull=Xmatrix_2_2_4_full, Xred = Xmatrix_2_2_4,
   pred_grid_full = pred_grid_full_2_2_4, pred_grid_red = pred_grid_red_2_2_4,
-  continuous_covar_inds = 5
+  continuous_covar_inds = 5,
+  model_selection = "auto"
 )
 
 mean_2_2_4 <- data.frame(check.names = FALSE, 
-  Mean_Infection_high = mustang$adj_group_means[, 1],
-  Mean_Infection_low = mustang$adj_group_means[, 2],
-  Mean_Mock_high = mustang$adj_group_means[, 3],
-  Mean_Mock_low = mustang$adj_group_means[, 4]
+  Mean_Infection_high = mustang$lsmeans[, 1],
+  Mean_Infection_low = mustang$lsmeans[, 2],
+  Mean_Mock_high = mustang$lsmeans[, 3],
+  Mean_Mock_low = mustang$lsmeans[, 4]
 )
 
 cmat = rbind(c(1, -1, 0, 0), c(1, 0, -1, 0), c(1, 0, 0, -1),

--- a/man/anova_test.Rd
+++ b/man/anova_test.Rd
@@ -13,6 +13,7 @@ anova_test(
   pval_adjust_fdr,
   pval_thresh,
   covariates,
+  model_selection,
   paired,
   equal_var,
   parallel
@@ -42,6 +43,13 @@ peptides are considered differentially expressed. Defaults to 0.05}
 
 \item{covariates}{A character vector with no more than two variable names
 that will be used as covariates in the IMD-ANOVA analysis.}
+
+\item{model_selection}{Character, one of 'full', 'reduced', or 'auto'
+indicating the model to be used in the ANOVA analysis. The default 'full' uses all main
+effects, covariates, and interactions between main effects. 'reduced' does 
+not consider interactions between main effects. 'auto' performs an F-test
+to determine if the full model is necessary. If the F-test is significant,
+the full model is used, otherwise the reduced model is used.}
 
 \item{paired}{logical; should the data be paired or not? if TRUE then the
 `f_data` element of `omicsData` is checked for a "Pair" column, an error is

--- a/man/imd_anova.Rd
+++ b/man/imd_anova.Rd
@@ -15,7 +15,7 @@ imd_anova(
   pval_adjust_g_fdr = "none",
   pval_thresh = 0.05,
   equal_var = TRUE,
-  model_selection = "full",
+  model_selection = "auto",
   parallel = TRUE
 )
 }
@@ -58,11 +58,11 @@ biomolecules are considered differentially expressed. Defaults to 0.05}
 \item{equal_var}{logical; should the variance across groups be assumed equal?}
 
 \item{model_selection}{Character, one of 'full', 'reduced', or 'auto'
-indicating the model to be used in the ANOVA analysis. The default 'full' uses all main
-effects, covariates, and interactions between main effects. 'reduced' does 
-not consider interactions between main effects. 'auto' performs an F-test
+indicating the model to be used in the ANOVA analysis. The default 'auto' performs an F-test
 to determine if the full model is necessary. If the F-test is significant,
-the full model is used, otherwise the reduced model is used.}
+the full model is used, otherwise the reduced model is used.  'full' uses all main
+effects, covariates, and interactions between main effects. 'reduced' does 
+not consider interactions between main effects (only covariates and marginal main effects).}
 
 \item{parallel}{logical value indicating whether or not to use a
 "doParallel" loop when running the G-Test with covariates. Defaults to

--- a/man/imd_anova.Rd
+++ b/man/imd_anova.Rd
@@ -15,6 +15,7 @@ imd_anova(
   pval_adjust_g_fdr = "none",
   pval_thresh = 0.05,
   equal_var = TRUE,
+  model_selection = "full",
   parallel = TRUE
 )
 }
@@ -55,6 +56,13 @@ to no p-value adjustment.}
 biomolecules are considered differentially expressed. Defaults to 0.05}
 
 \item{equal_var}{logical; should the variance across groups be assumed equal?}
+
+\item{model_selection}{Character, one of 'full', 'reduced', or 'auto'
+indicating the model to be used in the ANOVA analysis. The default 'full' uses all main
+effects, covariates, and interactions between main effects. 'reduced' does 
+not consider interactions between main effects. 'auto' performs an F-test
+to determine if the full model is necessary. If the F-test is significant,
+the full model is used, otherwise the reduced model is used.}
 
 \item{parallel}{logical value indicating whether or not to use a
 "doParallel" loop when running the G-Test with covariates. Defaults to

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -113,8 +113,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // two_factor_anova_cpp
-List two_factor_anova_cpp(arma::mat data, arma::mat X_full, arma::mat X_red, arma::colvec group_ids, arma::mat pred_grid_full, arma::mat pred_grid_red, arma::uvec continuous_covar_inds, arma::uvec group_ids_pred);
-RcppExport SEXP _pmartR_two_factor_anova_cpp(SEXP dataSEXP, SEXP X_fullSEXP, SEXP X_redSEXP, SEXP group_idsSEXP, SEXP pred_grid_fullSEXP, SEXP pred_grid_redSEXP, SEXP continuous_covar_indsSEXP, SEXP group_ids_predSEXP) {
+List two_factor_anova_cpp(arma::mat data, arma::mat X_full, arma::mat X_red, arma::colvec group_ids, arma::mat pred_grid_full, arma::mat pred_grid_red, arma::uvec continuous_covar_inds, arma::uvec group_ids_pred, int model_selection);
+RcppExport SEXP _pmartR_two_factor_anova_cpp(SEXP dataSEXP, SEXP X_fullSEXP, SEXP X_redSEXP, SEXP group_idsSEXP, SEXP pred_grid_fullSEXP, SEXP pred_grid_redSEXP, SEXP continuous_covar_indsSEXP, SEXP group_ids_predSEXP, SEXP model_selectionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -126,7 +126,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::mat >::type pred_grid_red(pred_grid_redSEXP);
     Rcpp::traits::input_parameter< arma::uvec >::type continuous_covar_inds(continuous_covar_indsSEXP);
     Rcpp::traits::input_parameter< arma::uvec >::type group_ids_pred(group_ids_predSEXP);
-    rcpp_result_gen = Rcpp::wrap(two_factor_anova_cpp(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred));
+    Rcpp::traits::input_parameter< int >::type model_selection(model_selectionSEXP);
+    rcpp_result_gen = Rcpp::wrap(two_factor_anova_cpp(data, X_full, X_red, group_ids, pred_grid_full, pred_grid_red, continuous_covar_inds, group_ids_pred, model_selection));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -218,7 +219,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pmartR_fold_change_ratio", (DL_FUNC) &_pmartR_fold_change_ratio, 2},
     {"_pmartR_fold_change_diff_na_okay", (DL_FUNC) &_pmartR_fold_change_diff_na_okay, 2},
     {"_pmartR_anova_cpp", (DL_FUNC) &_pmartR_anova_cpp, 8},
-    {"_pmartR_two_factor_anova_cpp", (DL_FUNC) &_pmartR_two_factor_anova_cpp, 8},
+    {"_pmartR_two_factor_anova_cpp", (DL_FUNC) &_pmartR_two_factor_anova_cpp, 9},
     {"_pmartR_group_comparison_anova_cpp", (DL_FUNC) &_pmartR_group_comparison_anova_cpp, 9},
     {"_pmartR_holm_cpp", (DL_FUNC) &_pmartR_holm_cpp, 1},
     {"_pmartR_ptukey_speed", (DL_FUNC) &_pmartR_ptukey_speed, 2},

--- a/src/imd_anova.cpp
+++ b/src/imd_anova.cpp
@@ -387,7 +387,7 @@ List two_factor_anova_cpp(arma::mat data,
                           arma::mat pred_grid_red,
                           arma::uvec continuous_covar_inds,
                           arma::uvec group_ids_pred,
-                          int model_selection = 1
+                          int model_selection = 2
                           ){
 
   int i,j;

--- a/tests/testthat/test_imd_anova.R
+++ b/tests/testthat/test_imd_anova.R
@@ -646,4 +646,87 @@ test_that('all tests conform to the decrees of the God of Stats', {
     "No IMD-ANOVA filter has been applied"
   )
  
+  ### Test that the default 'full' model_selection is equal when which_X is 1 and unequal otherwise for two factor cases.
+  afruit_2_1_4_full <- imd_anova(afilta_2_1_4,
+    test_method = "anova",
+    model_selection = "full"
+  )
+  
+  # check equality of indices where auto uses the full model
+  full_idx = attr(afruit_2_1_4, 'which_X') == 1
+  
+  expect_equal(
+    data.frame(afruit_2_1_4[full_idx,]),
+    data.frame(afruit_2_1_4_full[full_idx,])
+  )
+  
+  # check non-equality of indices where auto does the reduced model
+  truth_df = data.frame(afruit_2_1_4[!full_idx,]) == data.frame(afruit_2_1_4_full[!full_idx,])
+
+  pval_idx = grep("^P_value", colnames(truth_df))
+  mean_idx = grep("^Mean", colnames(truth_df))
+  all_idx = c(pval_idx, mean_idx)
+  
+  expect_false(any(truth_df[, all_idx], na.rm=T))
+  
+  afruit_2_2_4_full <- imd_anova(afilta_2_2_4,
+    test_method = "anova",
+    model_selection = "full"
+  )
+
+  full_idx = attr(afruit_2_2_4, 'which_X') == 1
+  
+  expect_equal(
+    data.frame(afruit_2_2_4[full_idx,]),
+    data.frame(afruit_2_2_4_full[full_idx,])
+  )
+  
+  truth_df = data.frame(afruit_2_2_4[!full_idx,]) == data.frame(afruit_2_2_4_full[!full_idx,])
+  
+  pval_idx = grep("^P_value", colnames(truth_df))
+  mean_idx = grep("^Mean", colnames(truth_df))
+  all_idx = c(pval_idx, mean_idx)
+  
+  expect_false(any(truth_df[, all_idx], na.rm=T))
+  
+  # Same equality checks for combined method
+  cfruit_2_1_4_full <- imd_anova(cfilta_2_1_4,
+    test_method = "combined",
+    model_selection = "full"
+  )
+  
+  full_idx = attr(cfruit_2_1_4, 'which_X') == 1
+  
+  expect_equal(
+    data.frame(cfruit_2_1_4[full_idx,]),
+    data.frame(cfruit_2_1_4_full[full_idx,])
+  )
+  
+  truth_df = data.frame(cfruit_2_1_4[!full_idx,]) == data.frame(cfruit_2_1_4_full[!full_idx,])
+  
+  pval_idx = grep("^P_value_A", colnames(truth_df))
+  mean_idx = grep("^Mean", colnames(truth_df))
+  all_idx = c(pval_idx, mean_idx)
+  
+  expect_false(any(truth_df[, all_idx], na.rm=T))
+  
+  cfruit_2_2_4_full <- imd_anova(cfilta_2_2_4,
+    test_method = "combined",
+    model_selection = "full"
+  )
+  
+  full_idx = attr(cfruit_2_2_4, 'which_X') == 1
+  
+  expect_equal(
+    data.frame(cfruit_2_2_4[full_idx,]),
+    data.frame(cfruit_2_2_4_full[full_idx,])
+  )
+  
+  truth_df = data.frame(cfruit_2_2_4[!full_idx,]) == data.frame(cfruit_2_2_4_full[!full_idx,])
+  
+  pval_idx = grep("^P_value_A", colnames(truth_df))
+  mean_idx = grep("^Mean", colnames(truth_df))
+  all_idx = c(pval_idx, mean_idx)
+  
+  expect_false(any(truth_df[, all_idx], na.rm=T))
 })

--- a/tests/testthat/test_imd_anova.R
+++ b/tests/testthat/test_imd_anova.R
@@ -17,11 +17,16 @@ test_that('all tests conform to the decrees of the God of Stats', {
 
   # Compare IMD-ANOVAly --------------------------------------------------------
 
+  # NOTE: There are three numbers that follow each object's name. The first
+  # number represents the number of main effects. The second number represents
+  # the number of covariates. The third represents the number of groups (across
+  # all main effects).
+  
   # Default comparisons ---------------
 
-  afruit_1_0_2 <- imd_anova(afilta_1_0_2, test_method = "anova")
-  gfruit_1_0_2 <- imd_anova(gfilta_1_0_2, test_method = "gtest")
-  cfruit_1_0_2 <- imd_anova(cfilta_1_0_2, test_method = "combined")
+  afruit_1_0_2 <- imd_anova(afilta_1_0_2, test_method = "anova", model_selection = "auto")
+  gfruit_1_0_2 <- imd_anova(gfilta_1_0_2, test_method = "gtest", model_selection = "auto")
+  cfruit_1_0_2 <- imd_anova(cfilta_1_0_2, test_method = "combined", model_selection = "auto")
 
   afruit_1_1_3 <- imd_anova(afilta_1_1_3,
     test_method = "anova"
@@ -35,46 +40,53 @@ test_that('all tests conform to the decrees of the God of Stats', {
   )
 
   afruit_1_2_3 <- imd_anova(afilta_1_2_3,
-    test_method = "anova"
+    test_method = "anova",
   )
   gfruit_1_2_3 <- imd_anova(gfilta_1_2_3,
     test_method = "gtest",
     parallel = FALSE
   )
   cfruit_1_2_3 <- imd_anova(cfilta_1_2_3,
-    test_method = "combined"
+    test_method = "combined",
   )
 
-  afruit_2_0_3 <- imd_anova(afilta_2_0_3, test_method = "anova")
-  gfruit_2_0_3 <- imd_anova(gfilta_2_0_3, test_method = "gtest")
-  cfruit_2_0_3 <- imd_anova(cfilta_2_0_3, test_method = "combined")
+  afruit_2_0_3 <- imd_anova(afilta_2_0_3, test_method = "anova", model_selection = "auto")
+  gfruit_2_0_3 <- imd_anova(gfilta_2_0_3, test_method = "gtest", model_selection = "auto")
+  cfruit_2_0_3 <- imd_anova(cfilta_2_0_3, test_method = "combined", model_selection = "auto")
 
   afruit_2_1_4 <- imd_anova(afilta_2_1_4,
-    test_method = "anova"
+    test_method = "anova",
+    model_selection = "auto"
   )
   gfruit_2_1_4 <- imd_anova(gfilta_2_1_4,
     test_method = "gtest",
+    model_selection = "auto",
     parallel = FALSE
   )
   cfruit_2_1_4 <- imd_anova(cfilta_2_1_4,
-    test_method = "combined"
+    test_method = "combined",
+    model_selection = "auto"
   )
 
   afruit_2_2_4 <- imd_anova(afilta_2_2_4,
-    test_method = "anova"
+    test_method = "anova",
+    model_selection = "auto"
   )
   gfruit_2_2_4 <- imd_anova(gfilta_2_2_4,
     test_method = "gtest",
+    model_selection = "auto",
     parallel = FALSE
   )
   cfruit_2_2_4 <- imd_anova(cfilta_2_2_4,
-    test_method = "combined"
+    test_method = "combined",
+    model_selection = "auto"
   )
 
   # Custom comparisons ---------------
 
   afruit_cus_2_0_3 <- imd_anova(
     omicsData = afilta_2_0_3,
+    model_selection = "auto",
     comparisons = data.frame(check.names = FALSE, 
       Control = c(
         "Infection_low",
@@ -92,6 +104,7 @@ test_that('all tests conform to the decrees of the God of Stats', {
 
   gfruit_cus_2_0_3 <- imd_anova(
     omicsData = gfilta_2_0_3,
+    model_selection = "auto",
     comparisons = data.frame(check.names = FALSE, 
       Control = c(
         "Infection_low",
@@ -168,14 +181,17 @@ test_that('all tests conform to the decrees of the God of Stats', {
 
   afruit_bon_2_0_3 <- imd_anova(afilta_2_0_3,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "bonferroni"
   )
   afruit_holm_2_0_3 <- imd_anova(afilta_2_0_3,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "holm"
   )
   afruit_tuk_2_0_3 <- imd_anova(afilta_2_0_3,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "tukey"
   )
   # Set a seed because the mvtnorm::pmvt function--which is called when doing a
@@ -183,6 +199,7 @@ test_that('all tests conform to the decrees of the God of Stats', {
   set.seed(4)
   afruit_dun_2_0_3 <- imd_anova(afilta_2_0_3,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "dunnett"
   )
   # Still gives an error even though all case-vs-control comparisons are being
@@ -192,14 +209,17 @@ test_that('all tests conform to the decrees of the God of Stats', {
 
   afruit_bon_2_1_4 <- imd_anova(afilta_2_1_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "bonferroni"
   )
   afruit_holm_2_1_4 <- imd_anova(afilta_2_1_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "holm"
   )
   afruit_tuk_2_1_4 <- imd_anova(afilta_2_1_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "tukey"
   )
   # Set a seed because the mvtnorm::pmvt function--which is called when doing a
@@ -207,19 +227,23 @@ test_that('all tests conform to the decrees of the God of Stats', {
   set.seed(8)
   afruit_dun_2_1_4 <- imd_anova(afilta_2_1_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "dunnett"
   )
 
   afruit_bon_2_2_4 <- imd_anova(afilta_2_2_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "bonferroni"
   )
   afruit_holm_2_2_4 <- imd_anova(afilta_2_2_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "holm"
   )
   afruit_tuk_2_2_4 <- imd_anova(afilta_2_2_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "tukey"
   )
   # Set a seed because the mvtnorm::pmvt function--which is called when doing a
@@ -227,6 +251,7 @@ test_that('all tests conform to the decrees of the God of Stats', {
   set.seed(11)
   afruit_dun_2_2_4 <- imd_anova(afilta_2_2_4,
     test_method = "anova",
+    model_selection = "auto",
     pval_adjust_a_multcomp = "dunnett"
   )
 
@@ -242,18 +267,22 @@ test_that('all tests conform to the decrees of the God of Stats', {
   )
   gfruit_bon_2_0_3 <- imd_anova(gfilta_2_0_3,
     test_method = "gtest",
+    model_selection = "auto",
     pval_adjust_g_multcomp = "bonferroni"
   )
   gfruit_holm_2_0_3 <- imd_anova(gfilta_2_0_3,
     test_method = "gtest",
+    model_selection = "auto",
     pval_adjust_g_multcomp = "holm"
   )
   gfruit_bon_2_1_4 <- imd_anova(gfilta_2_1_4,
     test_method = "gtest",
+    model_selection = "auto",
     pval_adjust_g_multcomp = "bonferroni"
   )
   gfruit_holm_2_1_4 <- imd_anova(gfilta_2_1_4,
     test_method = "gtest",
+    model_selection = "auto",
     pval_adjust_g_multcomp = "holm"
   )
 
@@ -470,13 +499,13 @@ test_that('all tests conform to the decrees of the God of Stats', {
     c(apply(data.frame(afruit_1_2_3$P_value_A_zombie_vs_human), 2, p.adjust, method = "bonferroni"))
   )
 
-  afruit_fdr_bon_2_0_3 <- imd_anova(afilta_2_0_3, test_method = "anova", pval_adjust_a_fdr = "bonferroni")
+  afruit_fdr_bon_2_0_3 <- imd_anova(afilta_2_0_3, test_method = "anova", pval_adjust_a_fdr = "bonferroni", model_selection = "auto")
   expect_equal(
     afruit_fdr_bon_2_0_3$P_value_A_Infection_high_vs_Mock_none,
     c(apply(data.frame(afruit_2_0_3$P_value_A_Infection_high_vs_Mock_none), 2, p.adjust, method = "bonferroni"))
   )
 
-  afruit_fdr_bon_2_1_4 <- imd_anova(afilta_2_1_4, test_method = "anova", pval_adjust_a_fdr = "bonferroni")
+  afruit_fdr_bon_2_1_4 <- imd_anova(afilta_2_1_4, test_method = "anova", pval_adjust_a_fdr = "bonferroni", model_selection = "auto")
   expect_equal(
     afruit_fdr_bon_2_1_4$P_value_A_Infection_high_vs_Infection_low,
     c(apply(data.frame(afruit_2_1_4$P_value_A_Infection_high_vs_Infection_low), 2, p.adjust, method = "bonferroni"))

--- a/tests/testthat/test_imd_anova.R
+++ b/tests/testthat/test_imd_anova.R
@@ -667,7 +667,8 @@ test_that('all tests conform to the decrees of the God of Stats', {
   mean_idx = grep("^Mean", colnames(truth_df))
   all_idx = c(pval_idx, mean_idx)
   
-  expect_false(any(truth_df[, all_idx], na.rm=T))
+  # It is technically possible some of these are the same or very similar....just check that most of them are not
+  expect_true(mean(truth_df[, all_idx], na.rm=T) < 0.001)
   
   afruit_2_2_4_full <- imd_anova(afilta_2_2_4,
     test_method = "anova",
@@ -687,7 +688,7 @@ test_that('all tests conform to the decrees of the God of Stats', {
   mean_idx = grep("^Mean", colnames(truth_df))
   all_idx = c(pval_idx, mean_idx)
   
-  expect_false(any(truth_df[, all_idx], na.rm=T))
+  expect_true(mean(truth_df[, all_idx], na.rm=T) < 0.001)
   
   # Same equality checks for combined method
   cfruit_2_1_4_full <- imd_anova(cfilta_2_1_4,
@@ -708,7 +709,7 @@ test_that('all tests conform to the decrees of the God of Stats', {
   mean_idx = grep("^Mean", colnames(truth_df))
   all_idx = c(pval_idx, mean_idx)
   
-  expect_false(any(truth_df[, all_idx], na.rm=T))
+  expect_true(mean(truth_df[, all_idx], na.rm=T) < 0.001)
   
   cfruit_2_2_4_full <- imd_anova(cfilta_2_2_4,
     test_method = "combined",
@@ -728,5 +729,5 @@ test_that('all tests conform to the decrees of the God of Stats', {
   mean_idx = grep("^Mean", colnames(truth_df))
   all_idx = c(pval_idx, mean_idx)
   
-  expect_false(any(truth_df[, all_idx], na.rm=T))
+  expect_true(mean(truth_df[, all_idx], na.rm=T) < 0.001)
 })


### PR DESCRIPTION
Added the ability in imd_anova to choose how the full or reduced model is selected via an argument `model_selection`.  There are 3 values:

'auto':  The default, how it worked before, use an F-test to determine whether to include interactions terms when we have 2 main effects, per biomolecule..
'full':  Always use the full model (interaction effect between main effects).
'reduced':  Always use the reduced model.

Closes #334 

@javenrflo @stratkg @lmbramer 
I'll merge this in soon and think about pushing up a new version if there's no objections.
